### PR TITLE
Use headless Chrome in Karma

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: trusty
 language: node_js
 
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,5 @@ addons:
   jwt:
     secure: "khLMTqppvGyyZgnHOYfVAV5cjAvAS9CUtnIj6s2zpq6q1FnYJSWXIJSBhgSDpQOXDT6lCpKuJJkm/9sJ5lI3J/QDLYDSdoSk2fCj9Hy02tY+mf7kV+PWfvdjvHOXORvJCrzsCF/Y1cDXdx+HSm7psYBmRNnDlC64FDG02z6GJY5JMpDEIO2GHyxg1dQLDYEK+5jLutphea5I9rgqDvAnBrPaLyhwqE9JvK9sabJBCSy3rMnArAayMyQCnJaHY4MBcXEjnfBOvhWozKAHorFKr7EmFvfXZtBQN5hqmHZmXQGjGj8NRnY5O9Zn2neTmJuUGJB0kR3BfLAWVk3pO235AN/SjQhgLMdheeg6zdi7pivk0nMavf41co9xpRZJQl9CD3GWSsYp+bYKXomTu3kDlkCvW5oFqVwcAkMjScxh0C6goeG1iMhe7IPszMsT8jWd0hOHJQGL2MtCEHzzZPCoLHXzcdPVoc04x13bEYzKm1rag7KnrAXZ2bDquv8WY5qsGihUqkbk0wwmi9k4mHqQwlz1BypVGVX5JSODQo9PQ+DIci3LSbfn9ILlVHaxa9dTdDc+0gp67VUjmeFigIS+9JOwL/kVsZPsHbfntCNazxrPAM36NskU40bKtS8N/6XtMPGH0lr1U7Ayko4XfHn2mv8nDWfIEhsuSpRDKMOMATQ="
 
-#before_script:
-#  - export DISPLAY=:99.0
-#  - sh -e /etc/init.d/xvfb start &
-#  - sleep 3
-
 cache:
   yarn: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ addons:
   jwt:
     secure: "khLMTqppvGyyZgnHOYfVAV5cjAvAS9CUtnIj6s2zpq6q1FnYJSWXIJSBhgSDpQOXDT6lCpKuJJkm/9sJ5lI3J/QDLYDSdoSk2fCj9Hy02tY+mf7kV+PWfvdjvHOXORvJCrzsCF/Y1cDXdx+HSm7psYBmRNnDlC64FDG02z6GJY5JMpDEIO2GHyxg1dQLDYEK+5jLutphea5I9rgqDvAnBrPaLyhwqE9JvK9sabJBCSy3rMnArAayMyQCnJaHY4MBcXEjnfBOvhWozKAHorFKr7EmFvfXZtBQN5hqmHZmXQGjGj8NRnY5O9Zn2neTmJuUGJB0kR3BfLAWVk3pO235AN/SjQhgLMdheeg6zdi7pivk0nMavf41co9xpRZJQl9CD3GWSsYp+bYKXomTu3kDlkCvW5oFqVwcAkMjScxh0C6goeG1iMhe7IPszMsT8jWd0hOHJQGL2MtCEHzzZPCoLHXzcdPVoc04x13bEYzKm1rag7KnrAXZ2bDquv8WY5qsGihUqkbk0wwmi9k4mHqQwlz1BypVGVX5JSODQo9PQ+DIci3LSbfn9ILlVHaxa9dTdDc+0gp67VUjmeFigIS+9JOwL/kVsZPsHbfntCNazxrPAM36NskU40bKtS8N/6XtMPGH0lr1U7Ayko4XfHn2mv8nDWfIEhsuSpRDKMOMATQ="
 
-before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start &
-  - sleep 3
+#before_script:
+#  - export DISPLAY=:99.0
+#  - sh -e /etc/init.d/xvfb start &
+#  - sleep 3
 
 cache:
   yarn: true

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -139,7 +139,7 @@ module.exports = function (config) {
         browsers: process.env.TRAVIS_BRANCH === 'master' && process.env.TRAVIS_PULL_REQUEST === 'false' ?
         // browsers: true ?
             Object.keys(sauceLabsLaunchers) :
-            ['Chrome'],
+            ['ChromeHeadless'],
 
 
         // Continuous Integration mode


### PR DESCRIPTION
Chrome 60 came out and now headless mode works on Windows, Mac, and Linux. :)
Used in Karma.
When developing the library: `yarn start` (or `npm start`)

This allows removing the xvfb hack in Travis and simplify CI configuration.