### PR TITLE
number-input no longer leaks default step/min/max properties into dom;

### DIFF
--- a/src/components/number-input/number-input.tsx
+++ b/src/components/number-input/number-input.tsx
@@ -23,7 +23,7 @@ export interface NumberInputProps {
     onInput?(value: string): void;
 }
 
-interface DefaultProps extends NumberInputProps {
+interface DefaultProps {
     step: number;
     min: number;
     max: number;
@@ -87,7 +87,7 @@ const DEFAULTS: DefaultProps = {
     onInput: noop
 };
 
-function getPropWithDefault<Prop extends keyof NumberInputProps>(
+function getPropWithDefault<Prop extends keyof NumberInputProps & keyof DefaultProps>(
     props: NumberInputProps,
     name: Prop
 ): (DefaultProps & NumberInputProps)[Prop] {

--- a/src/components/number-input/number-input.tsx
+++ b/src/components/number-input/number-input.tsx
@@ -23,6 +23,14 @@ export interface NumberInputProps {
     onInput?(value: string): void;
 }
 
+interface DefaultProps extends NumberInputProps {
+    step: number;
+    min: number;
+    max: number;
+    onChange(value?: number): void;
+    onInput(value: string): void;
+}
+
 export type SlotElement = React.ReactElement<{'data-slot': string}>;
 
 export interface Affix {
@@ -71,7 +79,7 @@ function getAffix(children: React.ReactNode): Affix {
         });
 }
 
-const DEFAULTS = {
+const DEFAULTS: DefaultProps = {
     step: 1,
     min: -Infinity,
     max: Infinity,
@@ -79,16 +87,19 @@ const DEFAULTS = {
     onInput: noop
 };
 
+function getPropWithDefault<Prop extends keyof NumberInputProps>(
+    props: NumberInputProps,
+    name: Prop
+): (DefaultProps & NumberInputProps)[Prop] {
+    return props[name] === undefined ? DEFAULTS[name] : props[name];
+}
+
 @SBComponent(styles)
 export class NumberInput extends React.Component<NumberInputProps, NumberInputState> {
     public static defaultProps = {
         onChange: DEFAULTS.onChange,
         onInput: DEFAULTS.onInput
     };
-
-    private step: number;
-    private min: number;
-    private max: number;
 
     private committed = true;
 
@@ -113,10 +124,6 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
     constructor(props: NumberInputProps) {
         super(props);
 
-        this.step = isNumber(props.step) ? props.step : DEFAULTS.step;
-        this.min = isNumber(props.min) ? props.min : DEFAULTS.min;
-        this.max = isNumber(props.max) ? props.max : DEFAULTS.max;
-
         this.state = {
             value: isNumber(props.value) ? props.value : props.defaultValue,
             focus: false,
@@ -129,10 +136,6 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
             this.committed = true;
             this.setState({value});
         }
-
-        this.step = isNumber(step) ? step : DEFAULTS.step;
-        this.min = isNumber(min) ? min : DEFAULTS.min;
-        this.max = isNumber(max) ? max : DEFAULTS.max;
     }
 
     public render() {
@@ -196,8 +199,8 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
     }
 
     private validate(value?: number) {
-        const min = this.min;
-        const max = this.max;
+        const min = getPropWithDefault(this.props, 'min');
+        const max = getPropWithDefault(this.props, 'max');
         return isNumber(value) ?
             Math.min(max, Math.max(min, value))
             : value;
@@ -232,7 +235,7 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
 
     private stepValue(direction: Direction, multiplier = 1) {
         const value = this.currentValue;
-        let step = this.step;
+        let step = getPropWithDefault(this.props, 'step');
 
         step = step * multiplier;
 

--- a/src/components/number-input/number-input.tsx
+++ b/src/components/number-input/number-input.tsx
@@ -71,15 +71,24 @@ function getAffix(children: React.ReactNode): Affix {
         });
 }
 
+const DEFAULTS = {
+    step: 1,
+    min: -Infinity,
+    max: Infinity,
+    onChange: noop,
+    onInput: noop
+};
+
 @SBComponent(styles)
 export class NumberInput extends React.Component<NumberInputProps, NumberInputState> {
     public static defaultProps = {
-        step: 1,
-        min: -Infinity,
-        max: Infinity,
-        onChange: noop,
-        onInput: noop
+        onChange: DEFAULTS.onChange,
+        onInput: DEFAULTS.onInput
     };
+
+    private step: number;
+    private min: number;
+    private max: number;
 
     private committed = true;
 
@@ -104,6 +113,10 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
     constructor(props: NumberInputProps) {
         super(props);
 
+        this.step = isNumber(props.step) ? props.step : DEFAULTS.step;
+        this.min = isNumber(props.min) ? props.min : DEFAULTS.min;
+        this.max = isNumber(props.max) ? props.max : DEFAULTS.max;
+
         this.state = {
             value: isNumber(props.value) ? props.value : props.defaultValue,
             focus: false,
@@ -111,13 +124,15 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
         };
     }
 
-    public componentWillReceiveProps({value, defaultValue}: NumberInputProps) {
-        const {min, max} = this.props;
-
+    public componentWillReceiveProps({min, max, step, value, defaultValue}: NumberInputProps) {
         if (defaultValue === undefined && value !== this.state.value) {
             this.committed = true;
             this.setState({value});
         }
+
+        this.step = isNumber(step) ? step : DEFAULTS.step;
+        this.min = isNumber(min) ? min : DEFAULTS.min;
+        this.max = isNumber(max) ? max : DEFAULTS.max;
     }
 
     public render() {
@@ -181,9 +196,10 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
     }
 
     private validate(value?: number) {
-        const {min, max} = this.props;
+        const min = this.min;
+        const max = this.max;
         return isNumber(value) ?
-            Math.min(max!, Math.max(min!, value))
+            Math.min(max, Math.max(min, value))
             : value;
     }
 
@@ -216,9 +232,9 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
 
     private stepValue(direction: Direction, multiplier = 1) {
         const value = this.currentValue;
-        let {step} = this.props;
+        let step = this.step;
 
-        step = step! * multiplier;
+        step = step * multiplier;
 
         const next = (direction === Direction.Increase ?
             isNumber(value) ? value + step : step :

--- a/test/components/number-input.spec.tsx
+++ b/test/components/number-input.spec.tsx
@@ -54,6 +54,29 @@ describe('<NumberInput />', () => {
         });
     });
 
+    it('should only set appropriate attributes on native input', async () => {
+        const value = 0;
+        const {select, waitForDom} = clientRenderer.render(
+            <NumberInput value={value} />
+        );
+
+        await waitForDom(() => {
+            const numberInput = select('NATIVE_INPUT_NUMBER');
+
+            expect(numberInput).to.be.present();
+            expect(numberInput).to.have.property('tagName', 'INPUT');
+
+            expect(numberInput).to.have.attribute('type', 'number');
+            expect(numberInput).not.to.have.attribute('min');
+            expect(numberInput).not.to.have.attribute('max');
+            expect(numberInput).not.to.have.attribute('step');
+            expect(numberInput).not.to.have.attribute('name');
+            expect(numberInput).not.to.have.attribute('required');
+
+            expect(numberInput).to.have.value(String(value));
+        });
+    });
+
     it('can be disabled', async () => {
         const value = 0;
         const {select, waitForDom} = clientRenderer.render(


### PR DESCRIPTION
Previously NumberInput leaked its default props like step, min and max into underlying native input attributes. This is no longer the case.