### PR TITLE
GlobalEvent component proposal

### DIFF
--- a/src/common/global-event.tsx
+++ b/src/common/global-event.tsx
@@ -2,9 +2,9 @@ import { Component } from 'react';
 
 export type Handler<E>  = (e: E) => void;
 
-export interface Props {
-    click?: Handler<MouseEvent>;
-}
+export type Props = {
+    [E in keyof WindowEventMap]?: Handler<WindowEventMap[E]>
+};
 
 export default class GlobalEvent extends Component<Props> {
 

--- a/src/common/global-event.tsx
+++ b/src/common/global-event.tsx
@@ -1,0 +1,36 @@
+import { Component } from 'react';
+
+export interface GlobalEventProps {
+    event: string;
+    debounce?: number;
+    handler: EventListener;
+}
+
+export default class GlobalEvent extends Component<GlobalEventProps> {
+
+    private emitter = window;
+
+    private timeoutId: NodeJS.Timer;
+
+    public componentDidMount() {
+        this.emitter.addEventListener(this.props.event, this.handler);
+    }
+
+    public componentWillUnmount() {
+        this.emitter.removeEventListener(this.props.event, this.handler);
+    }
+
+    private handler = (e: Event) => {
+        const { debounce, handler } = this.props;
+
+        if (debounce == null) {
+            handler(e);
+            return;
+        }
+
+        clearTimeout(this.timeoutId);
+        this.timeoutId = setTimeout(() => {
+            handler(e);
+        }, debounce);
+    }
+}

--- a/src/common/global-event.tsx
+++ b/src/common/global-event.tsx
@@ -1,9 +1,7 @@
 import { Component } from 'react';
 
-export type Handler<E>  = (e: E) => void;
-
 export type Props = {
-    [E in keyof WindowEventMap]?: Handler<WindowEventMap[E]>
+    [EventName in keyof WindowEventMap]?: (event: WindowEventMap[EventName]) => void;
 };
 
 export default class GlobalEvent extends Component<Props> {

--- a/src/common/global-event.tsx
+++ b/src/common/global-event.tsx
@@ -9,17 +9,17 @@ export default class GlobalEvent extends Component<Props> {
     private emitter = window;
 
     public componentDidMount() {
-        this.forEachEvent(name => this.subscribe(name, this.props[name] as EventListener));
+        this.forEachEvent((name, listener) => this.subscribe(name, listener));
     }
 
     public componentWillUnmount() {
-        this.forEachEvent(name => this.unsubscribe(name, this.props[name] as EventListener));
+        this.forEachEvent((name, listener) => this.unsubscribe(name, listener));
     }
 
     public componentWillReceiveProps(props: Props) {
-        this.forEachEvent(name => {
-            if (this.props[name] !== props[name]) {
-                this.unsubscribe(name, this.props[name] as EventListener);
+        this.forEachEvent((name, listener) => {
+            if (listener !== props[name]) {
+                this.unsubscribe(name, listener);
                 props[name] && this.subscribe(name, props[name] as EventListener);
             }
         });
@@ -29,18 +29,18 @@ export default class GlobalEvent extends Component<Props> {
         return null;
     }
 
-    private forEachEvent(fn: (name: keyof Props) => void) {
-        Object
+    private forEachEvent(fn: (name: keyof Props, listener: EventListener) => void) {
+        (Object
             .keys(this.props)
-            .filter(name => name !== 'children')
-            .forEach(fn);
+            .filter(name => name !== 'children') as Array<keyof Props>)
+            .forEach(name => fn(name, this.props[name] as EventListener));
     }
 
-    private subscribe(event: string, handler: EventListener) {
-        this.emitter.addEventListener(event, handler);
+    private subscribe(event: string, listener: EventListener) {
+        this.emitter.addEventListener(event, listener);
     }
 
-    private unsubscribe(event: string, handler: EventListener) {
-        this.emitter.removeEventListener(event, handler);
+    private unsubscribe(event: string, listener: EventListener) {
+        this.emitter.removeEventListener(event, listener);
     }
 }

--- a/src/common/global-event.tsx
+++ b/src/common/global-event.tsx
@@ -10,11 +10,18 @@ export default class GlobalEvent extends Component<GlobalEventProps> {
     private emitter = window;
 
     public componentDidMount() {
-        this.emitter.addEventListener(this.props.event, this.handler);
+        this.subscribe(this.props.event);
     }
 
     public componentWillUnmount() {
-        this.emitter.removeEventListener(this.props.event, this.handler);
+        this.unsubscribe(this.props.event);
+    }
+
+    public componentWillReceiveProps({event}: GlobalEventProps) {
+        if (event !== this.props.event) {
+            this.unsubscribe(this.props.event);
+            this.subscribe(event);
+        }
     }
 
     public render() {
@@ -24,5 +31,13 @@ export default class GlobalEvent extends Component<GlobalEventProps> {
     private handler = (e: Event) => {
         const { handler } = this.props;
         handler(e);
+    }
+
+    private subscribe(event: string) {
+        this.emitter.addEventListener(event, this.handler);
+    }
+
+    private unsubscribe(event: string) {
+        this.emitter.removeEventListener(event, this.handler);
     }
 }

--- a/src/common/global-event.tsx
+++ b/src/common/global-event.tsx
@@ -6,8 +6,6 @@ export type Props = {
 
 export default class GlobalEvent extends Component<Props> {
 
-    private emitter = window;
-
     public componentDidMount() {
         this.forEachEvent((name, listener) => this.subscribe(name, listener));
     }
@@ -37,10 +35,10 @@ export default class GlobalEvent extends Component<Props> {
     }
 
     private subscribe(event: string, listener: EventListener) {
-        this.emitter.addEventListener(event, listener);
+        window && window.addEventListener(event, listener);
     }
 
     private unsubscribe(event: string, listener: EventListener) {
-        this.emitter.removeEventListener(event, listener);
+        window && window.removeEventListener(event, listener);
     }
 }

--- a/src/common/global-event.tsx
+++ b/src/common/global-event.tsx
@@ -9,8 +9,6 @@ export default class GlobalEvent extends Component<GlobalEventProps> {
 
     private emitter = window;
 
-    private timeoutId: NodeJS.Timer;
-
     public componentDidMount() {
         this.emitter.addEventListener(this.props.event, this.handler);
     }

--- a/src/common/global-event.tsx
+++ b/src/common/global-event.tsx
@@ -6,6 +6,10 @@ export type Props = {
 
 export default class GlobalEvent extends Component<Props> {
 
+    public shouldComponentUpdate() {
+        return false;
+    }
+
     public componentDidMount() {
         this.forEachEvent((name, listener) => this.subscribe(name, listener));
     }

--- a/src/common/global-event.tsx
+++ b/src/common/global-event.tsx
@@ -2,7 +2,6 @@ import { Component } from 'react';
 
 export interface GlobalEventProps {
     event: string;
-    debounce?: number;
     handler: EventListener;
 }
 
@@ -20,17 +19,12 @@ export default class GlobalEvent extends Component<GlobalEventProps> {
         this.emitter.removeEventListener(this.props.event, this.handler);
     }
 
+    public render() {
+        return null;
+    }
+
     private handler = (e: Event) => {
-        const { debounce, handler } = this.props;
-
-        if (debounce == null) {
-            handler(e);
-            return;
-        }
-
-        clearTimeout(this.timeoutId);
-        this.timeoutId = setTimeout(() => {
-            handler(e);
-        }, debounce);
+        const { handler } = this.props;
+        handler(e);
     }
 }

--- a/test/components/global-event.spec.tsx
+++ b/test/components/global-event.spec.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { ClientRenderer, expect, simulate, sinon } from 'test-drive-react';
+import GlobalEvent from '../../src/common/global-event';
+
+describe('<GlobalEvent />', () => {
+    const clientRenderer = new ClientRenderer();
+    afterEach(() => clientRenderer.cleanup());
+
+    it('should exist', () => {
+        expect(GlobalEvent).to.exist;
+    });
+
+    describe('mounting', () => {
+        it('should call the handler with corresponding event', async () => {
+            const handler = sinon.spy();
+            const {waitForDom} = clientRenderer.render(
+                <GlobalEvent event="click" handler={handler} />
+            );
+
+            await waitForDom(() => {
+                simulate.click(document.body);
+                expect(handler).to.have.been.called;
+            });
+        });
+    });
+});

--- a/test/components/global-event.spec.tsx
+++ b/test/components/global-event.spec.tsx
@@ -20,11 +20,10 @@ describe('<GlobalEvent />', () => {
 
     describe('mount', () => {
         it('should add an event listener on window object when mounted', async () => {
-            const event = 'click';
             const handler = () => {};
 
             render(
-                <GlobalEvent event={event} handler={handler} />,
+                <GlobalEvent click={handler} />,
                 container
             );
 
@@ -34,11 +33,10 @@ describe('<GlobalEvent />', () => {
 
     describe('unmount', () => {
         it('should remove an event listener on window object when unmounted', async () => {
-            const event = 'click';
             const handler = () => {};
 
             render(
-                <GlobalEvent event={event} handler={handler} />,
+                <GlobalEvent click={handler} />,
                 container
             );
 
@@ -48,50 +46,25 @@ describe('<GlobalEvent />', () => {
         });
     });
 
-    describe('passing event prop', () => {
-        it('should remove listener for old event and add listener to the new one', () => {
-            const originalEvent = 'original.event';
-            const newEvent = 'new.event';
-
-            class Fixture extends React.Component<{}, {event: string, handler: () => void}> {
-
-                public state = {event: originalEvent, handler: () => {}};
-
-                public render() {
-                    const {event, handler} = this.state;
-                    return <GlobalEvent event={event} handler={handler} />;
-                }
-            }
-
-            const fixture = render(<Fixture />, container) as Fixture;
-
-            fixture.setState({event: newEvent});
-
-            expect(windowStub.removeEventListener).to.have.been.calledWith(originalEvent);
-            expect(windowStub.addEventListener).to.have.been.calledWith(newEvent);
-        });
-    });
-
     describe('passing handler props', () => {
         it('should call new handler but not the old one', () => {
-            const originalEvent = 'event';
             const originalHandler = sinon.spy();
             const newHandler = sinon.spy();
 
-            class Fixture extends React.Component<{}, {event: string, handler: () => void}> {
+            class Fixture extends React.Component<{}, {handler: () => void}> {
 
-                public state = {event: originalEvent, handler: originalHandler};
+                public state = {handler: originalHandler};
 
                 public render() {
-                    const {event, handler} = this.state;
-                    return <GlobalEvent event={event} handler={handler} />;
+                    const {handler} = this.state;
+                    return <GlobalEvent click={handler} />;
                 }
             }
 
             const fixture = render(<Fixture />, container) as Fixture;
             fixture.setState({handler: newHandler});
 
-            windowStub.simulate(originalEvent);
+            windowStub.simulate('click');
 
             expect(originalHandler).not.to.have.been.called;
             expect(newHandler).to.have.been.calledOnce;

--- a/test/components/global-event.spec.tsx
+++ b/test/components/global-event.spec.tsx
@@ -1,22 +1,22 @@
 import * as React from 'react';
 import {render, unmountComponentAtNode} from 'react-dom';
-import {SinonMock} from 'sinon';
 import { ClientRenderer, expect, simulate, sinon } from 'test-drive-react';
 import GlobalEvent from '../../src/common/global-event';
+import WindowStub from '../stubs/window.stub';
 
 describe('<GlobalEvent />', () => {
     const clientRenderer = new ClientRenderer();
-    let emitterMock: SinonMock;
+    let windowStub: WindowStub;
     let container: HTMLElement;
 
-    beforeEach(() => emitterMock = sinon.mock(window));
+    beforeEach(() => windowStub = new WindowStub());
     beforeEach(() => {
         container = document.createElement('div');
         container.setAttribute('style', 'position: fixed; top: 0; left: 0; right: 0;');
         document.body.appendChild(container);
     });
 
-    afterEach(() => emitterMock.restore());
+    afterEach(() => windowStub.sandbox.restore());
     afterEach(() => document.body.removeChild(container));
 
     afterEach(() => clientRenderer.cleanup());
@@ -26,14 +26,12 @@ describe('<GlobalEvent />', () => {
             const event = 'click';
             const handler = () => {};
 
-            emitterMock.expects('addEventListener').once();
-
             render(
                 <GlobalEvent event={event} handler={handler} />,
                 container
             );
 
-            emitterMock.verify();
+            expect(windowStub.addEventListener).to.have.been.calledOnce;
         });
     });
 
@@ -42,8 +40,6 @@ describe('<GlobalEvent />', () => {
             const event = 'click';
             const handler = () => {};
 
-            emitterMock.expects('removeEventListener').once();
-
             render(
                 <GlobalEvent event={event} handler={handler} />,
                 container
@@ -51,7 +47,57 @@ describe('<GlobalEvent />', () => {
 
             unmountComponentAtNode(container);
 
-            emitterMock.verify();
+            expect(windowStub.removeEventListener).to.have.been.calledOnce;
+        });
+    });
+
+    describe('passing event prop', () => {
+        it('should remove listener for old event and add listener to the new one', () => {
+            const originalEvent = 'original.event';
+            const newEvent = 'new.event';
+
+            class Fixture extends React.Component<{}, {event: string, handler: () => void}> {
+
+                public state = {event: originalEvent, handler: () => {}};
+
+                public render() {
+                    const {event, handler} = this.state;
+                    return <GlobalEvent event={event} handler={handler} />;
+                }
+            }
+
+            const fixture = render(<Fixture />, container) as Fixture;
+
+            fixture.setState({event: newEvent});
+
+            expect(windowStub.removeEventListener).to.have.been.calledWith(originalEvent);
+            expect(windowStub.addEventListener).to.have.been.calledWith(newEvent);
+        });
+    });
+
+    describe('passing handler props', () => {
+        it('should call new handler but not the old one', () => {
+            const originalEvent = 'event';
+            const originalHandler = sinon.spy();
+            const newHandler = sinon.spy();
+
+            class Fixture extends React.Component<{}, {event: string, handler: () => void}> {
+
+                public state = {event: originalEvent, handler: originalHandler};
+
+                public render() {
+                    const {event, handler} = this.state;
+                    return <GlobalEvent event={event} handler={handler} />;
+                }
+            }
+
+            const fixture = render(<Fixture />, container) as Fixture;
+            fixture.setState({handler: newHandler});
+
+            windowStub.simulate(originalEvent);
+
+            expect(originalHandler).not.to.have.been.called;
+            expect(newHandler).to.have.been.calledOnce;
         });
     });
 

--- a/test/components/global-event.spec.tsx
+++ b/test/components/global-event.spec.tsx
@@ -1,33 +1,23 @@
 import * as React from 'react';
-import {render, unmountComponentAtNode} from 'react-dom';
-import {expect, sinon} from 'test-drive-react';
+import {ClientRenderer, expect, sinon} from 'test-drive-react';
 import GlobalEvent, {Props as GlobalEventProps} from '../../src/common/global-event';
 import WindowStub from '../stubs/window.stub';
 
 describe('<GlobalEvent />', () => {
+    const clientRenderer = new ClientRenderer();
     let windowStub: WindowStub;
-    let container: HTMLElement;
 
     beforeEach(() => windowStub = new WindowStub());
-    beforeEach(() => {
-        container = document.createElement('div');
-        container.setAttribute('style', 'position: fixed; top: 0; left: 0; right: 0;');
-        document.body.appendChild(container);
-    });
 
     afterEach(() => windowStub.sandbox.restore());
-    afterEach(() => {
-        unmountComponentAtNode(container);
-        document.body.removeChild(container);
-    });
+    afterEach(() => clientRenderer.cleanup());
 
     describe('mount', () => {
-        it('should add an event listener on window object when mounted', async () => {
+        it('should add an event listener on window object when mounted', () => {
             const handler = () => {};
 
-            render(
-                <GlobalEvent click={handler} />,
-                container
+            clientRenderer.render(
+                <GlobalEvent click={handler} />
             );
 
             expect(windowStub.addEventListener).to.have.been.calledOnce;
@@ -35,15 +25,14 @@ describe('<GlobalEvent />', () => {
     });
 
     describe('unmount', () => {
-        it('should remove an event listener on window object when unmounted', async () => {
+        it('should remove an event listener on window object when unmounted', () => {
             const handler = () => {};
 
-            render(
-                <GlobalEvent click={handler} />,
-                container
+            clientRenderer.render(
+                <GlobalEvent click={handler} />
             );
 
-            unmountComponentAtNode(container);
+            clientRenderer.cleanup();
 
             expect(windowStub.removeEventListener).to.have.been.calledOnce;
         });
@@ -67,9 +56,9 @@ describe('<GlobalEvent />', () => {
         it('should not call a handler after it was unset', () => {
             const originalListener = sinon.spy();
 
-            const fixture = render(
-                <Fixture listener={originalListener} />, container
-            ) as Fixture;
+            const fixture = clientRenderer.render(
+                <Fixture listener={originalListener} />
+            ).result as Fixture;
             fixture.setState({listener: undefined});
 
             windowStub.simulate('click');
@@ -81,9 +70,9 @@ describe('<GlobalEvent />', () => {
             const originalListener = sinon.spy();
             const newListener = sinon.spy();
 
-            const fixture = render(
-                <Fixture listener={originalListener} />, container
-            ) as Fixture;
+            const fixture = clientRenderer.render(
+                <Fixture listener={originalListener} />
+            ).result as Fixture;
             fixture.setState({listener: newListener});
 
             windowStub.simulate('click');
@@ -100,9 +89,12 @@ describe('<GlobalEvent />', () => {
             const onMouseMove = sinon.spy();
             const onMouseUp = sinon.spy();
 
-            render(
-                <GlobalEvent mousedown={onMouseDown} mousemove={onMouseMove} mouseup={onMouseUp} />,
-                container
+            clientRenderer.render(
+                <GlobalEvent
+                    mousedown={onMouseDown}
+                    mousemove={onMouseMove}
+                    mouseup={onMouseUp}
+                />
             );
 
             windowStub.simulate('mousedown');

--- a/test/components/global-event.spec.tsx
+++ b/test/components/global-event.spec.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import {render, unmountComponentAtNode} from 'react-dom';
-import { ClientRenderer, expect, simulate, sinon } from 'test-drive-react';
+import {expect, sinon} from 'test-drive-react';
 import GlobalEvent from '../../src/common/global-event';
 import WindowStub from '../stubs/window.stub';
 
 describe('<GlobalEvent />', () => {
-    const clientRenderer = new ClientRenderer();
     let windowStub: WindowStub;
     let container: HTMLElement;
 
@@ -18,8 +17,6 @@ describe('<GlobalEvent />', () => {
 
     afterEach(() => windowStub.sandbox.restore());
     afterEach(() => document.body.removeChild(container));
-
-    afterEach(() => clientRenderer.cleanup());
 
     describe('mount', () => {
         it('should add an event listener on window object when mounted', async () => {

--- a/test/components/global-event.spec.tsx
+++ b/test/components/global-event.spec.tsx
@@ -1,26 +1,58 @@
 import * as React from 'react';
+import {render, unmountComponentAtNode} from 'react-dom';
+import {SinonMock} from 'sinon';
 import { ClientRenderer, expect, simulate, sinon } from 'test-drive-react';
 import GlobalEvent from '../../src/common/global-event';
 
 describe('<GlobalEvent />', () => {
     const clientRenderer = new ClientRenderer();
+    let emitterMock: SinonMock;
+    let container: HTMLElement;
+
+    beforeEach(() => emitterMock = sinon.mock(window));
+    beforeEach(() => {
+        container = document.createElement('div');
+        container.setAttribute('style', 'position: fixed; top: 0; left: 0; right: 0;');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => emitterMock.restore());
+    afterEach(() => document.body.removeChild(container));
+
     afterEach(() => clientRenderer.cleanup());
 
-    it('should exist', () => {
-        expect(GlobalEvent).to.exist;
-    });
+    describe('mount', () => {
+        it('should add an event listener on window object when mounted', async () => {
+            const event = 'click';
+            const handler = () => {};
 
-    describe('mounting', () => {
-        it('should call the handler with corresponding event', async () => {
-            const handler = sinon.spy();
-            const {waitForDom} = clientRenderer.render(
-                <GlobalEvent event="click" handler={handler} />
+            emitterMock.expects('addEventListener').once();
+
+            render(
+                <GlobalEvent event={event} handler={handler} />,
+                container
             );
 
-            await waitForDom(() => {
-                simulate.click(document.body);
-                expect(handler).to.have.been.called;
-            });
+            emitterMock.verify();
         });
     });
+
+    describe('unmount', () => {
+        it('should remove an event listener on window object when unmounted', async () => {
+            const event = 'click';
+            const handler = () => {};
+
+            emitterMock.expects('removeEventListener').once();
+
+            render(
+                <GlobalEvent event={event} handler={handler} />,
+                container
+            );
+
+            unmountComponentAtNode(container);
+
+            emitterMock.verify();
+        });
+    });
+
 });

--- a/test/stubs/window.stub.ts
+++ b/test/stubs/window.stub.ts
@@ -1,0 +1,64 @@
+import {SinonSandbox, SinonStub} from 'sinon';
+import {sinon} from 'test-drive-react';
+
+type EventListener = (...args: any[]) => any;
+
+function stubbed(sandbox: SinonSandbox, method: keyof Window, stub: (...args: any[]) => any) {
+    return sandbox.stub(window, method, stub);
+}
+
+export default class WindowStub {
+
+    public sandbox = sinon.sandbox.create();
+
+    public addEventListener = stubbed(
+        this.sandbox, 'addEventListener',
+        (type: string, listener: EventListener) => {
+            const events = this.events;
+            if (events.has(type)) {
+                const listeners = events.get(type);
+                (listeners as EventListener[]).push(listener);
+            } else {
+                const listeners = [listener];
+                events.set(type, listeners);
+            }
+        }
+    );
+
+    public removeEventListener = stubbed(
+        this.sandbox, 'removeEventListener',
+        (type: string, listener?: EventListener) => {
+            const events = this.events;
+
+            if (events.has(type)) {
+                const listeners = events.get(type);
+
+                if (listener) {
+                    const index = listeners!.indexOf(listener);
+
+                    if (index >= 0) {
+                        listeners!.splice(index, 1);
+
+                        if (listeners!.length === 0) {
+                            events.delete(type);
+                        }
+                    }
+                } else {
+                    events.delete(type);
+                }
+            }
+        }
+    );
+
+    private events = new Map<string, EventListener[]>();
+
+    public simulate(type: string) {
+        const events = this.events;
+
+        if (events.has(type)) {
+            const listeners = events.get(type);
+            listeners!.forEach(listener => listener());
+        }
+    }
+
+}

--- a/test/stubs/window.stub.ts
+++ b/test/stubs/window.stub.ts
@@ -1,21 +1,21 @@
 import {SinonSandbox, SinonStub} from 'sinon';
 import {sinon} from 'test-drive-react';
 
-type EventListener = (...args: any[]) => any;
+type EventListener = (e?: Partial<Event>) => any;
 
-function stubWinowMethod(
+function stubWindowMethod(
     sandbox: SinonSandbox,
     method: keyof Window,
-    stub: EventListener
+    stub: (...args: any[]) => any
 ) {
-    return sandbox.stub(window, method, stub);
+    return sandbox.stub(window, method).callsFake(stub);
 }
 
 export default class WindowStub {
 
     public sandbox = sinon.sandbox.create();
 
-    public addEventListener = stubWinowMethod(
+    public addEventListener = stubWindowMethod(
         this.sandbox, 'addEventListener',
         (type: string, listener: EventListener) => {
             const events = this.events;
@@ -29,7 +29,7 @@ export default class WindowStub {
         }
     );
 
-    public removeEventListener = stubWinowMethod(
+    public removeEventListener = stubWindowMethod(
         this.sandbox, 'removeEventListener',
         (type: string, listener?: EventListener) => {
             const events = this.events;
@@ -56,12 +56,12 @@ export default class WindowStub {
 
     private events = new Map<string, EventListener[]>();
 
-    public simulate(type: string) {
+    public simulate(type: string, event?: Partial<Event>) {
         const events = this.events;
 
         if (events.has(type)) {
             const listeners = events.get(type);
-            listeners!.forEach(listener => listener());
+            listeners!.forEach(listener => listener(event));
         }
     }
 

--- a/test/stubs/window.stub.ts
+++ b/test/stubs/window.stub.ts
@@ -3,7 +3,11 @@ import {sinon} from 'test-drive-react';
 
 type EventListener = (...args: any[]) => any;
 
-function stubbed(sandbox: SinonSandbox, method: keyof Window, stub: (...args: any[]) => any) {
+function stubWinowMethod(
+    sandbox: SinonSandbox,
+    method: keyof Window,
+    stub: EventListener
+) {
     return sandbox.stub(window, method, stub);
 }
 
@@ -11,7 +15,7 @@ export default class WindowStub {
 
     public sandbox = sinon.sandbox.create();
 
-    public addEventListener = stubbed(
+    public addEventListener = stubWinowMethod(
         this.sandbox, 'addEventListener',
         (type: string, listener: EventListener) => {
             const events = this.events;
@@ -25,7 +29,7 @@ export default class WindowStub {
         }
     );
 
-    public removeEventListener = stubbed(
+    public removeEventListener = stubWinowMethod(
         this.sandbox, 'removeEventListener',
         (type: string, listener?: EventListener) => {
             const events = this.events;

--- a/yarn.lock
+++ b/yarn.lock
@@ -567,6 +567,14 @@ bytes@2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.5.0.tgz#4c9423ea2d252c270c41b2bdefeff9bb6b62c06a"
 
+c3-platform@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/c3-platform/-/c3-platform-1.0.2.tgz#d91c8a7834ee4b68ac17f02d91336d52ddddd5f1"
+  dependencies:
+    karma-junit-reporter "^1.2.0"
+    karma-webdriver-launcher "^1.0.5"
+    karma-webpack "^2.0.4"
+
 callsite@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
@@ -779,15 +787,11 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.0:
+commander@2.9.0, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
-
-commander@^2.9.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
 component-bind@1.0.0:
   version "1.0.0"
@@ -1167,13 +1171,9 @@ di@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
 
-diff@3.2.0:
+diff@3.2.0, diff@^3.1.0, diff@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
-
-diff@^3.1.0, diff@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
 
 diffie-hellman@^5.0.0:
   version "5.0.2"
@@ -1986,13 +1986,9 @@ https-proxy-agent@^1.0.0, https-proxy-agent@~1.0.0:
     debug "2"
     extend "3"
 
-iconv-lite@0.4.15:
+iconv-lite@0.4.15, iconv-lite@~0.4.13:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
-
-iconv-lite@~0.4.13:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
@@ -2334,6 +2330,13 @@ karma-firefox-launcher@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/karma-firefox-launcher/-/karma-firefox-launcher-1.0.1.tgz#ce58f47c2013a88156d55a5d61337c099cf5bb51"
 
+karma-junit-reporter@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/karma-junit-reporter/-/karma-junit-reporter-1.2.0.tgz#4f9c40cedfb1a395f8aef876abf96189917c6396"
+  dependencies:
+    path-is-absolute "^1.0.0"
+    xmlbuilder "8.2.2"
+
 karma-mocha@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/karma-mocha/-/karma-mocha-1.3.0.tgz#eeaac7ffc0e201eb63c467440d2b69c7cf3778bf"
@@ -2347,6 +2350,12 @@ karma-sauce-launcher@^1.1.0:
     q "^1.4.1"
     sauce-connect-launcher "^0.17.0"
     saucelabs "^1.3.0"
+    wd "^1.0.0"
+
+karma-webdriver-launcher@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/karma-webdriver-launcher/-/karma-webdriver-launcher-1.0.5.tgz#b1c3cb347f26e786039c15abf7f19a7791e8ddd7"
+  dependencies:
     wd "^1.0.0"
 
 karma-webpack@^2.0.4:
@@ -4336,7 +4345,7 @@ stylis@^3.2.3:
   version "3.2.8"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.2.8.tgz#9b23a3e06597f7944a3d9ae880d5796248b8784f"
 
-supports-color@3.1.2:
+supports-color@3.1.2, supports-color@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -4346,7 +4355,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.1.1, supports-color@^3.2.3:
+supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
@@ -4922,6 +4931,10 @@ ws@1.1.2:
 wtf-8@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
+
+xmlbuilder@8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
 
 xmlhttprequest-ssl@1.5.3:
   version "1.5.3"


### PR DESCRIPTION
This PR introduces a proposal of how global event handlers (on `window`) could be implemented. PR also holds a supposed test and window object stub. `window` stub could be improved by wrapping it into a proper driver object. Also, `window` object itself should be injected into `<GlobalEvent />` component with context, this way we could inject a mock nicely and handle environment differences in server-side rendering scenario.