### PR TITLE
Volodymyrk/193 stepper button submits

### DIFF
--- a/src/components/number-input/number-input.st.css
+++ b/src/components/number-input/number-input.st.css
@@ -74,6 +74,7 @@
 
     border: none;
     height: auto;
+    outline: none;
 
     -moz-appearance: textfield;
 }

--- a/src/components/number-input/number-input.tsx
+++ b/src/components/number-input/number-input.tsx
@@ -139,12 +139,12 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
     }
 
     public render() {
-        const {value, focus, error} = this.state;
+        const {value, focus} = this.state;
         const {
             step, min, max,
             placeholder, name,
             disabled, required,
-            children
+            children, error
         } = this.props;
         const disableIncrement = disabled || (isNumber(value) && value >= max!);
         const disableDecrement = disabled || (isNumber(value) && value <= min!);
@@ -153,8 +153,9 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
         return (
             <div
                 cssStates={{
-                    disabled: Boolean(this.props.disabled),
-                    focus, error
+                    disabled: Boolean(disabled),
+                    error: Boolean(error),
+                    focus
                 }}
                 onFocus={this.handleFocus}
                 onBlur={this.handleBlur}

--- a/src/components/stepper/stepper.st.css
+++ b/src/components/stepper/stepper.st.css
@@ -23,12 +23,6 @@
 .control {
     width: 100%;
 
-    display: flex;
-
-    justify-content: center;
-    align-content: center;
-    align-items: center;
-
     position: absolute;
 
     margin: 0;

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -22,6 +22,7 @@ export const Stepper: React.StatelessComponent<StepperProps> = SBStateless(
     }) => (
         <div {...props}>
             <button
+                type="button"
                 tabIndex={-1}
                 data-automation-id="STEPPER_INCREMENT"
                 className={`${buttonStyles.root} control up`}
@@ -31,6 +32,7 @@ export const Stepper: React.StatelessComponent<StepperProps> = SBStateless(
                 <ChevronUpIcon className="control-icon" />
             </button>
             <button
+                type="button"
                 tabIndex={-1}
                 data-automation-id="STEPPER_DECREMENT"
                 className={`${buttonStyles.root} control down`}

--- a/src/style/default-theme/controls/input.st.css
+++ b/src/style/default-theme/controls/input.st.css
@@ -28,6 +28,7 @@
     font-size: value(fontSize);
     font-weight: value(fontWeight);
     line-height: value(lineHeight);
+    margin: 0;
     padding: 6px 12px;
     height: value(inputHeight);
     width: value(inputWidth);


### PR DESCRIPTION
`<Stepper />` was using `button` element without type which caused submits when used in `form` elements. Also, addressed inconsistent number input placeholder and stepper arrow layouts in safari.