### PR TITLE
updated tslint-wix-react version;

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ts-loader": "^2.3.3",
     "ts-node": "^3.3.0",
     "tslint": "^5.6.0",
-    "tslint-wix-react": "^2.0.0",
+    "tslint-wix-react": "^3.0.0",
     "typescript": "~2.4.2",
     "webpack": "^3.5.5",
     "webpack-dev-server": "^2.7.1",


### PR DESCRIPTION
Updated `tslint-wix-react` to version `^3.0.0`. It holds new `indent` rule enforcing 4 spaces indentation. No fixes needed to be applied.