### PR TITLE
Toggle - added className property

### DIFF
--- a/src/components/toggle/toggle.tsx
+++ b/src/components/toggle/toggle.tsx
@@ -3,6 +3,7 @@ import {SBComponent} from 'stylable-react-component';
 import style from './toggle.st.css';
 
 export interface Props {
+    className?: string;
     checked?: boolean;
     error?: boolean;
     disabled?: boolean;


### PR DESCRIPTION
typescript will not compile without this when you will try to add `className` to `Toggle`