### PR TITLE
TimePicker - exclude from root-element.spec

### DIFF
--- a/test/contracts/root-element.spec.tsx
+++ b/test/contracts/root-element.spec.tsx
@@ -7,7 +7,7 @@ import {isReactComponent} from '../utils/is-react-component';
 const allComponents = Object.keys(WixReactComponents);
 const failingComponents = [
     'TreeView', 'NumberInput', 'Toggle', 'BirthdayPicker',
-    'RadioButton', 'RadioGroup', 'Portal', 'Popup'
+    'RadioButton', 'RadioGroup', 'Portal', 'Popup', 'TimePicker'
 ];
 
 describe('Root Element contract', function() {


### PR DESCRIPTION
Excluding TimePicker from `root-element.spec` since that was no product requirements be such element