### PR TITLE
<TimePicker> - fixed focus bugs and ampm aligment

### DIFF
--- a/demo/components/time-picker-demo.tsx
+++ b/demo/components/time-picker-demo.tsx
@@ -3,37 +3,18 @@ import {TimePicker} from '../../src';
 import {is12TimeFormat} from '../../src/components/time-picker/utils';
 
 export class TimePickerDemo extends React.Component<any, any> {
-    public intervalId: any;
     constructor() {
         super();
         this.state = {
-            now: new Date(),
             value1: '01:55',
             value2: null
         };
     }
-    public componentDidMount() {
-        this.intervalId = setInterval(() => {
-            this.setState({now: new Date()});
-        }, 1000) as any;
-    }
-    public componentWillUnmount() {
-        clearInterval(this.intervalId as any);
-    }
     public render() {
-        const currentTime = [
-            this.state.now.getHours(),
-            this.state.now.getMinutes()
-        ].join(':');
         return (
             <div>
                 <div>
                     System time format: <code>{is12TimeFormat ? 'ampm' : '24h'}</code>
-                </div>
-                <h3>Current time (read-only)</h3>
-                <div>
-                    <TimePicker value={currentTime}/>
-                    <span style={{marginLeft: 20}}>{currentTime}</span>
                 </div>
 
                 <h3>Controlled 24 time format</h3>

--- a/src/components/time-picker/time-picker.st.css
+++ b/src/components/time-picker/time-picker.st.css
@@ -31,8 +31,6 @@
     user-select: none;
     -webkit-user-select: none;
 
-    /* preventing window DPI scaling artifacts*/
-    padding: 0.3px;
     padding-left: 9px;
 }
 
@@ -139,15 +137,11 @@
     background: white;
 }
 
-.ampm-wrap {
-    display: inline-flex;
+.ampm {
+    display: inline-block;
     background-color: inherit;
     cursor: pointer;
-
-    height: 100%;
-    vertical-align: bottom;
-    align-items: center;
-
+    vertical-align: baseline;
 }
 .ampm:hover {
     color: value(PR3);

--- a/src/components/time-picker/time-picker.st.css
+++ b/src/components/time-picker/time-picker.st.css
@@ -28,6 +28,8 @@
     height: value(height);
     min-width: value(width);
     display: inline-block;
+    user-select: none;
+    -webkit-user-select: none;
 
     /* preventing window DPI scaling artifacts*/
     padding: 0.3px;

--- a/src/components/time-picker/time-picker.tsx
+++ b/src/components/time-picker/time-picker.tsx
@@ -151,6 +151,7 @@ export class TimePicker extends React.Component<Props, State> {
                 {!isTouchTimeInputSupported && !disabled && isValueSet &&
                     <Stepper
                         className="stepper"
+                        onMouseDown={this.onStepperMouseDown}
                         onUp={this.onStepperUp}
                         onDown={this.onStepperDown}
                     />
@@ -270,6 +271,10 @@ export class TimePicker extends React.Component<Props, State> {
         }
     }
 
+    private onStepperMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+        e.preventDefault();
+    }
+
     private onStepperUp = (e: React.MouseEvent<HTMLButtonElement>) => this.changeValue(1, e.shiftKey ? 10 : 1);
     private onStepperDown = (e: React.MouseEvent<HTMLButtonElement>) => this.changeValue(-1, e.shiftKey ? 10 : 1);
 
@@ -340,8 +345,9 @@ export class TimePicker extends React.Component<Props, State> {
     }
     private onBlur = (e: React.SyntheticEvent<HTMLElement>) => {
         const name = e.currentTarget instanceof HTMLInputElement && e.currentTarget.name;
-        const update: Pick<State, TimeSegment | 'focus'> = {
-            focus: false
+        const update: Pick<State, TimeSegment | 'focus' | 'currentSegment'> = {
+            focus: false,
+            currentSegment: 'hh'
         };
         if (isTimeSegment(name)) {
             update[name] = formatTimeChunk(this.state[name]!);

--- a/src/components/time-picker/time-picker.tsx
+++ b/src/components/time-picker/time-picker.tsx
@@ -126,19 +126,17 @@ export class TimePicker extends React.Component<Props, State> {
                     </div>
                 )}
                 {format === 'ampm' &&
-                    <div className="ampm-wrap">
-                        <div
-                            data-automation-id="TIME_PICKER_AMPM"
-                            className="ampm"
-                            ref={elem => this.segments.ampm = elem}
-                            tabIndex={disabled || isTouchTimeInputSupported ? -1 : 0}
-                            children={ampmLabels[ampm]}
-                            onMouseDown={this.onAmpmMouseDown}
-                            onFocus={this.onAmpmFocus}
-                            onBlur={this.onBlur}
-                            onKeyDown={this.onKeyDown}
-                        />
-                    </div>
+                    <div
+                        data-automation-id="TIME_PICKER_AMPM"
+                        className="ampm"
+                        ref={elem => this.segments.ampm = elem}
+                        tabIndex={disabled || isTouchTimeInputSupported ? -1 : 0}
+                        children={ampmLabels[ampm]}
+                        onMouseDown={this.onAmpmMouseDown}
+                        onFocus={this.onAmpmFocus}
+                        onBlur={this.onBlur}
+                        onKeyDown={this.onKeyDown}
+                    />
                 }
                 {placeholder && !isValueSet &&
                     <div

--- a/src/components/time-picker/time-picker.tsx
+++ b/src/components/time-picker/time-picker.tsx
@@ -103,6 +103,7 @@ export class TimePicker extends React.Component<Props, State> {
                     disabled: disabled!,
                     empty: !isValueSet
                 }}
+                onMouseDown={this.onRootMouseDown}
             >
                 {timeSegments.map(segment =>
                     <div key={segment} className={'input-wrap ' + segment}>
@@ -144,7 +145,7 @@ export class TimePicker extends React.Component<Props, State> {
                         data-automation-id="TIME_PICKER_PLACEHOLDER"
                         className="placeholder"
                         children={placeholder}
-                        onClick={this.onPlaceholderClick}
+                        onMouseDown={this.onRootMouseDown}
                     />
                 }
                 {!isTouchTimeInputSupported && !disabled && isValueSet &&
@@ -233,13 +234,18 @@ export class TimePicker extends React.Component<Props, State> {
         this.updateSegmentValue(currentSegment, newValue);
     }
 
-    private onPlaceholderClick = () => {
+    private onRootMouseDown = (e: React.SyntheticEvent<HTMLDivElement>) => {
+        if (e.target !== e.currentTarget) {
+            return;
+        }
+        e.preventDefault();
         if (isTouchTimeInputSupported) {
             this.nativeInput!.focus();
         } else {
             this.segments.hh!.focus();
         }
     }
+
     private onStepperUp = () => this.changeValue(1);
     private onStepperDown = () => this.changeValue(-1);
 

--- a/test/components/time-picker.spec.tsx
+++ b/test/components/time-picker.spec.tsx
@@ -791,51 +791,59 @@ describe('<TimePicker/>', () => {
 
     describeDesktop('Render <TimePickerDemo/>', () => {
         let renderer: any;
-        let hh1: any;
-        let hh2: any;
-        let mm1: any;
-        let mm2: any;
-        let stepperUp1: any;
-        let stepperUp2: any;
+        let firstInputHH: any;
+        let firstInputMM: any;
+        let firstStepperUp: any;
+        let secondInputHH: any;
+        let secondInputMM: any;
+        let secondStepperUp: any;
         beforeEach(() => {
             renderer = clientRenderer.render(<TimePickerDemo/>);
-            hh1 = renderer.select('TIME_PICKER_DEMO_CONTROLLED_24', 'TIME_PICKER_INPUT_HH');
-            hh2 = renderer.select('TIME_PICKER_DEMO_CONTROLLED_AMPM', 'TIME_PICKER_INPUT_HH');
-            mm1 = renderer.select('TIME_PICKER_DEMO_CONTROLLED_24', 'TIME_PICKER_INPUT_MM');
-            mm2 = renderer.select('TIME_PICKER_DEMO_CONTROLLED_AMPM', 'TIME_PICKER_INPUT_MM');
-            stepperUp1 = renderer.select('TIME_PICKER_DEMO_CONTROLLED_24', 'STEPPER_INCREMENT');
-            stepperUp2 = renderer.select('TIME_PICKER_DEMO_CONTROLLED_AMPM', 'STEPPER_INCREMENT');
+            firstInputHH = renderer.select('TIME_PICKER_DEMO_CONTROLLED_24', 'TIME_PICKER_INPUT_HH');
+            firstInputMM = renderer.select('TIME_PICKER_DEMO_CONTROLLED_24', 'TIME_PICKER_INPUT_MM');
+            firstStepperUp = renderer.select('TIME_PICKER_DEMO_CONTROLLED_24', 'STEPPER_INCREMENT');
+            secondInputHH = renderer.select('TIME_PICKER_DEMO_CONTROLLED_AMPM', 'TIME_PICKER_INPUT_HH');
+            secondInputMM = renderer.select('TIME_PICKER_DEMO_CONTROLLED_AMPM', 'TIME_PICKER_INPUT_MM');
+            secondStepperUp = renderer.select('TIME_PICKER_DEMO_CONTROLLED_AMPM', 'STEPPER_INCREMENT');
         });
 
-        describe('focus on hh on first input', () => {
-            it('should keep focus on hh input', () => {
-                simulate.focus(hh1);
-                simulate.click(stepperUp1);
-                expect(document.activeElement).to.equal(hh1);
+        describe('focus on hh segment on first input', () => {
+            it('should keep focus on hh segment of first input', () => {
+                simulate.focus(firstInputHH);
+                simulate.click(firstStepperUp);
+                expect(document.activeElement).to.equal(firstInputHH);
             });
         });
 
-        describe('focus on mm on first input', () => {
-            it('should keep focus on mm input', () => {
-                simulate.focus(mm1);
-                simulate.click(stepperUp1);
-                expect(document.activeElement).to.equal(mm1);
+        describe('focus on mm segment on first input', () => {
+            it('should keep focus on mm segment on first input', () => {
+                simulate.focus(firstInputMM);
+                simulate.click(firstStepperUp);
+                expect(document.activeElement).to.equal(firstInputMM);
             });
         });
 
-        describe('initial click on stepper', () => {
-            it('should keep focus on hh input', () => {
-                simulate.click(stepperUp1);
-                expect(document.activeElement).to.equal(hh1);
+        describe('initial click on stepper inside first input', () => {
+            it('should move focus on hh segment on first input', () => {
+                simulate.click(firstStepperUp);
+                expect(document.activeElement).to.equal(firstInputHH);
             });
         });
 
-        describe('focus on mm1 then mm2 then click on stepperUp1', () => {
-            it('should set focus on hh on first input', () => {
-                simulate.focus(mm1);
-                simulate.focus(mm2);
-                simulate.click(stepperUp1);
-                expect(document.activeElement).to.equal(hh1);
+        describe('focus on mm segment on first input then on mm segment on second input then', () => {
+            beforeEach(() => {
+                simulate.focus(firstInputMM);
+            });
+            describe('focus on mm segment on second input', () => {
+                beforeEach(() => {
+                    simulate.focus(secondInputMM);
+                });
+                describe('click on stepper in first input', () => {
+                    it('should set focus on hh on first input', () => {
+                        simulate.click(firstStepperUp);
+                        expect(document.activeElement).to.equal(firstInputHH);
+                    });
+                });
             });
         });
     });

--- a/test/components/time-picker.spec.tsx
+++ b/test/components/time-picker.spec.tsx
@@ -811,7 +811,7 @@ describe('<TimePicker/>', () => {
             it('should keep focus on hh segment of first input', () => {
                 simulate.focus(firstInputHH);
                 simulate.click(firstStepperUp);
-                expect(document.activeElement).to.equal(firstInputHH);
+                expect(document.activeElement === firstInputHH).to.be.true;
             });
         });
 
@@ -819,14 +819,14 @@ describe('<TimePicker/>', () => {
             it('should keep focus on mm segment on first input', () => {
                 simulate.focus(firstInputMM);
                 simulate.click(firstStepperUp);
-                expect(document.activeElement).to.equal(firstInputMM);
+                expect(document.activeElement === firstInputMM).to.be.true;
             });
         });
 
         describe('initial click on stepper inside first input', () => {
             it('should move focus on hh segment on first input', () => {
                 simulate.click(firstStepperUp);
-                expect(document.activeElement).to.equal(firstInputHH);
+                expect(document.activeElement === firstInputHH).to.be.true;
             });
         });
 
@@ -843,7 +843,7 @@ describe('<TimePicker/>', () => {
                         simulate.focus(firstStepperUp);
                         await new Promise(resolve => setTimeout(resolve, 500));
                         simulate.click(firstStepperUp);
-                        expect(document.activeElement).to.equal(firstInputHH);
+                        expect(document.activeElement === firstInputHH).to.be.true;
                     });
                 });
             });

--- a/test/components/time-picker.spec.tsx
+++ b/test/components/time-picker.spec.tsx
@@ -830,22 +830,21 @@ describe('<TimePicker/>', () => {
             });
         });
 
-        describe.only('focus on mm segment on first input then on mm segment on second input then', () => {
+        describe('focus on mm segment on first input then on mm segment on second input then', () => {
             beforeEach(() => {
                 simulate.click(firstInputMM);
                 simulate.focus(firstInputMM);
             });
             describe('focus on mm segment on second input', () => {
                 beforeEach(() => {
+                    simulate.blur(firstInputMM);
                     simulate.click(secondInputMM);
                     simulate.focus(secondInputMM);
                 });
                 describe('click on stepper in first input', () => {
-                    it('should set focus on hh on first input', async () => {
+                    it('should set focus on hh on first input', () => {
                         simulate.focus(firstStepperUp);
-                        await new Promise(resolve => setTimeout(resolve, 300));
                         simulate.click(firstStepperUp);
-                        await new Promise(resolve => setTimeout(resolve, 300));
                         expect(document.activeElement === firstInputHH).to.be.true;
                     });
                 });

--- a/test/components/time-picker.spec.tsx
+++ b/test/components/time-picker.spec.tsx
@@ -1,6 +1,7 @@
 import * as keycode from 'keycode';
 import * as React from 'react';
 import {ClientRenderer, expect, simulate, sinon} from 'test-drive-react';
+import {TimePickerDemo} from '../../demo/components/time-picker-demo';
 import {TimePicker} from '../../src';
 import styles from '../../src/components/time-picker/time-picker.st.css';
 import {
@@ -784,6 +785,57 @@ describe('<TimePicker/>', () => {
             });
             it('onChange should be callen with "16:55"', () => {
                 expect(onChange).to.be.calledWithExactly('16:55');
+            });
+        });
+    });
+
+    describeDesktop('Render <TimePickerDemo/>', () => {
+        let renderer: any;
+        let hh1: any;
+        let hh2: any;
+        let mm1: any;
+        let mm2: any;
+        let stepperUp1: any;
+        let stepperUp2: any;
+        beforeEach(() => {
+            renderer = clientRenderer.render(<TimePickerDemo/>);
+            hh1 = renderer.select('TIME_PICKER_DEMO_CONTROLLED_24', 'TIME_PICKER_INPUT_HH');
+            hh2 = renderer.select('TIME_PICKER_DEMO_CONTROLLED_AMPM', 'TIME_PICKER_INPUT_HH');
+            mm1 = renderer.select('TIME_PICKER_DEMO_CONTROLLED_24', 'TIME_PICKER_INPUT_MM');
+            mm2 = renderer.select('TIME_PICKER_DEMO_CONTROLLED_AMPM', 'TIME_PICKER_INPUT_MM');
+            stepperUp1 = renderer.select('TIME_PICKER_DEMO_CONTROLLED_24', 'STEPPER_INCREMENT');
+            stepperUp2 = renderer.select('TIME_PICKER_DEMO_CONTROLLED_AMPM', 'STEPPER_INCREMENT');
+        });
+
+        describe('focus on hh on first input', () => {
+            it('should keep focus on hh input', () => {
+                simulate.focus(hh1);
+                simulate.click(stepperUp1);
+                expect(document.activeElement).to.equal(hh1);
+            });
+        });
+
+        describe('focus on mm on first input', () => {
+            it('should keep focus on mm input', () => {
+                simulate.focus(mm1);
+                simulate.click(stepperUp1);
+                expect(document.activeElement).to.equal(mm1);
+            });
+        });
+
+        describe('initial click on stepper', () => {
+            it('should keep focus on hh input', () => {
+                simulate.click(stepperUp1);
+                expect(document.activeElement).to.equal(hh1);
+            });
+        });
+
+        describe('focus on mm1 then mm2 then click on stepperUp1', () => {
+            it('should set focus on hh on first input', () => {
+                simulate.focus(mm1);
+                simulate.focus(mm2);
+                simulate.click(stepperUp1);
+                expect(document.activeElement).to.equal(hh1);
             });
         });
     });

--- a/test/components/time-picker.spec.tsx
+++ b/test/components/time-picker.spec.tsx
@@ -839,7 +839,9 @@ describe('<TimePicker/>', () => {
                     simulate.focus(secondInputMM);
                 });
                 describe('click on stepper in first input', () => {
-                    it('should set focus on hh on first input', () => {
+                    it('should set focus on hh on first input', async () => {
+                        simulate.focus(firstStepperUp);
+                        await new Promise(resolve => setTimeout(resolve, 500));
                         simulate.click(firstStepperUp);
                         expect(document.activeElement).to.equal(firstInputHH);
                     });

--- a/test/components/time-picker.spec.tsx
+++ b/test/components/time-picker.spec.tsx
@@ -830,19 +830,22 @@ describe('<TimePicker/>', () => {
             });
         });
 
-        describe('focus on mm segment on first input then on mm segment on second input then', () => {
+        describe.only('focus on mm segment on first input then on mm segment on second input then', () => {
             beforeEach(() => {
+                simulate.click(firstInputMM);
                 simulate.focus(firstInputMM);
             });
             describe('focus on mm segment on second input', () => {
                 beforeEach(() => {
+                    simulate.click(secondInputMM);
                     simulate.focus(secondInputMM);
                 });
                 describe('click on stepper in first input', () => {
                     it('should set focus on hh on first input', async () => {
                         simulate.focus(firstStepperUp);
-                        await new Promise(resolve => setTimeout(resolve, 500));
+                        await new Promise(resolve => setTimeout(resolve, 300));
                         simulate.click(firstStepperUp);
+                        await new Promise(resolve => setTimeout(resolve, 300));
                         expect(document.activeElement === firstInputHH).to.be.true;
                     });
                 });


### PR DESCRIPTION
related #240 

* [x] Clicking on empty area in TimePicker will put focus on hours
* [x] Initial click on stepper should have hours even after previous focus on minutes
* [x] Fixed ampm vertical aligment
* [x] Remove "current time" from demo (confusing)