### PR TITLE
Upgrade wix-react-tools, and use new decorators

### DIFF
--- a/demo/components/checkbox-demo.tsx
+++ b/demo/components/checkbox-demo.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {CheckBox, CheckBoxChangeEvent, CheckBoxIconProps} from '../../src';
 import buttonStyle from '../../src/style/default-theme/controls/button.st.css';
 import style from './checkbox-demo.st.css';
 
-export const demoCheckBoxText: string = 'Yes, I\'m over 18 years old';
+export const demoCheckBoxText: string = `Yes, I'm over 18 years old`;
 
-@SBComponent(style)
-export class CheckBoxDemo extends React.Component<{}, {}> {
+@stylable(style)
+export class CheckBoxDemo extends React.Component {
     public render() {
         return (
             <div>

--- a/demo/components/selection-list-demo.tsx
+++ b/demo/components/selection-list-demo.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
+
 import {divider, Option, SelectionList} from '../../src/components/selection-list';
 import demoStyle from './selection-list-demo.st.css';
 
@@ -46,7 +47,7 @@ export class FoodList extends React.Component {
     private onChange = (value: string) => this.setState({value});
 }
 
-@SBComponent(demoStyle)
+@stylable(demoStyle)
 class EmojiList extends React.Component {
     public state = {value: 'Crocodile'};
     private dataSchema = {value: 'name', label: 'icon'};
@@ -85,7 +86,7 @@ class EmojiList extends React.Component {
     private onChange = (value: string) => this.setState({value});
 }
 
-@SBComponent(demoStyle)
+@stylable(demoStyle)
 class TextStyleList extends React.Component {
     public state = {value: 'heading'};
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "keycode": "^2.1.9",
     "mobx": "^3.2.2",
     "mobx-react": "^4.2.2",
-    "wix-react-tools": "^2.3.0"
+    "wix-react-tools": "3.0.0-1"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.42",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "keycode": "^2.1.9",
     "mobx": "^3.2.2",
     "mobx-react": "^4.2.2",
-    "wix-react-tools": "3.0.0-1"
+    "wix-react-tools": "3.0.0-2"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.42",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "keycode": "^2.1.9",
     "mobx": "^3.2.2",
     "mobx-react": "^4.2.2",
-    "stylable-react-component": "^1.0.3",
-    "wix-react-tools": "^2.1.0"
+    "wix-react-tools": "^2.3.0"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.42",

--- a/src/components/birthday-picker/birthday-picker.tsx
+++ b/src/components/birthday-picker/birthday-picker.tsx
@@ -1,7 +1,7 @@
 import {autorun, computed, observable, reaction} from 'mobx';
 import {observer} from 'mobx-react';
 import * as React from 'react';
-import {root} from 'wix-react-tools';
+import {properties} from 'wix-react-tools';
 
 export function dateFromYearMonthDay(
     y: string,
@@ -67,15 +67,15 @@ const Select: React.SFC<SelectProps> = props => (
     </select>
 );
 
-export interface BirthdayPickerProps {
+export interface BirthdayPickerProps extends properties.Props {
     value?: Date;
     minDate?: Date;
     maxDate?: Date;
     onChange?: (newValue: Date) => void;
 }
-
 @observer
-export class BirthdayPicker extends React.Component<BirthdayPickerProps, {}> {
+@properties
+export class BirthdayPicker extends React.Component<BirthdayPickerProps> {
     public static defaultProps: BirthdayPickerProps = {
         maxDate: new Date(),
         onChange: () => {}
@@ -119,10 +119,8 @@ export class BirthdayPicker extends React.Component<BirthdayPickerProps, {}> {
     }
 
     public render() {
-        const rootProps = root(this.props, {'data-automation-id': 'BIRTHDAY_PICKER', 'className': ''});
-
         return (
-            <span {...rootProps}>
+            <span data-automation-id="BIRTHDAY_PICKER">
                 <Select
                     automationId="BIRTHDAY_PICKER_DAY"
                     value={this.day}

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
-import {root} from 'wix-react-tools';
+import {properties, stylable} from 'wix-react-tools';
 import {noop} from '../../utils';
 import styles from './checkbox.st.css';
 
@@ -71,7 +70,8 @@ const DefaultIndeterminateSVG: React.SFC<CheckBoxIconProps> = props => {
     );
 };
 
-@SBComponent(styles)
+@properties
+@stylable(styles)
 export class CheckBox extends React.Component<Partial<CheckBoxProps>, CheckBoxState> {
     public static defaultProps: Partial<CheckBoxProps> = {
         boxIcon: DefaultCheckBoxSVG,
@@ -93,23 +93,18 @@ export class CheckBox extends React.Component<Partial<CheckBoxProps>, CheckBoxSt
         const BoxIcon = boxIcon!;
         const IndeterminateIcon = indeterminateIcon!;
         const TickIcon = tickIcon!;
-        const rootProps = root(this.props, {
-            'data-automation-id': 'CHECKBOX_ROOT',
-            'className': 'root'
-        });
-        const cssStates = {
-            checked: value!,
-            disabled: disabled!,
-            readonly: readonly!,
-            indeterminate: indeterminate!,
-            focused: this.state.isFocused
-        };
 
         return (
             <div
-                {...rootProps as React.HTMLAttributes<HTMLDivElement>}
+                data-automation-id="CHECKBOX_ROOT"
                 onClick={this.handleRootClick}
-                cssStates={cssStates}
+                style-state={{
+                    checked: value!,
+                    disabled: disabled!,
+                    readonly: readonly!,
+                    indeterminate: indeterminate!,
+                    focused: this.state.isFocused
+                }}
                 role="checkbox"
                 aria-checked={indeterminate ? 'mixed' : value}
             >

--- a/src/components/date-picker/calendar.tsx
+++ b/src/components/date-picker/calendar.tsx
@@ -1,7 +1,7 @@
 import {computed} from 'mobx';
 import {observer} from 'mobx-react';
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {
     getDayNames,
     getDaysInMonth,
@@ -26,8 +26,8 @@ export interface CalendarProps {
 
 const monthNames = getMonthNames();
 
-@SBComponent(styles)
 @observer
+@stylable(styles)
 export class Calendar extends React.Component<CalendarProps, {}> {
     public render() {
         return (

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -1,14 +1,13 @@
 import * as keycode from 'keycode';
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
-import {root} from 'wix-react-tools';
+import {properties, stylable} from 'wix-react-tools';
 import inputStyles from '../../style/default-theme/controls/input.st.css';
 import {Calendar} from './calendar';
 import styles from './date-picker.st.css';
 
 const invalidDate: string = 'Invalid Date';
 
-export interface DatePickerProps {
+export interface DatePickerProps extends properties.Props {
     value?: Date;
     placeholder?: string;
     openOnFocus?: boolean;
@@ -27,7 +26,8 @@ export interface DatePickerState {
     highlightFocusedDate: boolean;
 }
 
-@SBComponent(styles)
+@properties
+@stylable(styles)
 export class DatePicker extends React.Component<DatePickerProps, DatePickerState> {
     public static defaultProps: DatePickerProps = {
         openOnFocus: true,
@@ -43,13 +43,8 @@ export class DatePicker extends React.Component<DatePickerProps, DatePickerState
     }
 
     public render() {
-        const rootProps = root(this.props, {
-            'data-automation-id': 'DATE_PICKER_ROOT',
-            'className': 'root'
-        }) as React.HTMLAttributes<HTMLDivElement>;
-
         return (
-            <div {...rootProps}>
+            <div data-automation-id="DATE_PICKER_ROOT">
                 <input
                     className={inputStyles.root + ' input'}
                     onKeyDown={this.onKeyDown}

--- a/src/components/date-picker/day.tsx
+++ b/src/components/date-picker/day.tsx
@@ -1,10 +1,9 @@
 import {observer} from 'mobx-react';
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
-import {root} from 'wix-react-tools';
+import {properties, stylable} from 'wix-react-tools';
 import styles from './date-picker.st.css';
 
-export interface DayProps {
+export interface DayProps extends properties.Props {
     day: number;
     selected?: boolean;
     currentDay?: boolean;
@@ -14,26 +13,21 @@ export interface DayProps {
     onSelect?(day: number): void;
 }
 
-@SBComponent(styles)
 @observer
+@properties
+@stylable(styles)
 export class Day extends React.Component<DayProps, {}> {
     public render() {
-        const cssStates = {
-            focused: this.props.focused!,
-            selected: this.props.selected!,
-            current: this.props.currentDay!,
-            inactive: this.props.partOfNextMonth! || this.props.partOfPrevMonth!
-        };
-
         return (
             <span
-                {...root(this.props,
-                    {   'data-automation-id': '',
-                        'className': 'calendarItem day'
-                    }) as React.HTMLAttributes<HTMLSpanElement>
-                }
+                className="calendarItem day"
                 onMouseDown={this.onMouseDown}
-                cssStates={cssStates}
+                style-state={{
+                    focused: this.props.focused!,
+                    selected: this.props.selected!,
+                    current: this.props.currentDay!,
+                    inactive: this.props.partOfNextMonth! || this.props.partOfPrevMonth!
+                }}
             >
                 {this.props.day}
             </span>

--- a/src/components/drop-down/drop-down.tsx
+++ b/src/components/drop-down/drop-down.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {SBComponent, SBStateless} from 'stylable-react-component';
-import {root} from 'wix-react-tools';
+import {properties, stylable} from 'wix-react-tools';
 import {SelectionList} from '../selection-list';
 import {CaretDown} from './drop-down-icons';
 import style from './drop-down.st.css';
@@ -10,14 +9,14 @@ export interface DropDownInputProps {
     onClick?: React.EventHandler<React.MouseEvent<HTMLDivElement>>;
 }
 
-export const DropDownInput: React.SFC<DropDownInputProps> = SBStateless(props => {
+export const DropDownInput = stylable(style)<React.SFC<DropDownInputProps>>((props: DropDownInputProps) => {
     return (
         <div data-automation-id="DROP_DOWN_INPUT" onClick={props.onClick} className="drop-down-input">
             <span className="label">{props.selectedItem ? props.selectedItem.label : 'Default Text'}</span>
             <CaretDown className="caret" />
         </div>
     );
-}, style);
+});
 
 export interface DropDownListProps {
     open: boolean;
@@ -26,7 +25,7 @@ export interface DropDownListProps {
     onItemClick?: (item: string) => void;
 }
 
-export const DropDownList: React.SFC<DropDownListProps> = SBStateless(props => {
+export const DropDownList = stylable(style)<React.SFC<DropDownListProps>>((props: DropDownListProps) => {
     if (!props.open) { return null; }
 
     return (
@@ -39,7 +38,7 @@ export const DropDownList: React.SFC<DropDownListProps> = SBStateless(props => {
             />
         </div>
     );
-}, style);
+});
 
 export interface DropDownItem {
     label: string;
@@ -53,7 +52,8 @@ export interface DropDownProps extends React.HTMLAttributes<HTMLDivElement> {
     onItemClick?: (item: DropDownItem) => void;
 }
 
-@SBComponent(style)
+@properties
+@stylable(style)
 export class DropDown extends React.Component<DropDownProps, {}> {
 
     public static defaultProps: DropDownProps = {items: [], onItemClick: () => {}, onInputClick: () => {}};
@@ -64,13 +64,8 @@ export class DropDown extends React.Component<DropDownProps, {}> {
     }
 
     public render() {
-        const rootProps = root(this.props, {
-            'data-automation-id': 'DROP_DOWN',
-            'className': 'drop-down'
-        });
-
         return (
-            <div data-automation-id="DROP_DOWN" {...rootProps}>
+            <div data-automation-id="DROP_DOWN" className="drop-down">
                 <DropDownInput selectedItem={this.props.selectedItem} onClick={this.props.onInputClick} />
                 <DropDownList
                     selectedItem={this.props.selectedItem}

--- a/src/components/number-input/number-input.tsx
+++ b/src/components/number-input/number-input.tsx
@@ -1,6 +1,7 @@
 import {codes as KeyCodes} from 'keycode';
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
+
 import inputStyles from '../../style/default-theme/controls/input.st.css';
 import {isNumber, noop} from '../../utils';
 import {Stepper} from '../stepper';
@@ -94,7 +95,7 @@ function getPropWithDefault<Prop extends keyof NumberInputProps & keyof DefaultP
     return props[name] === undefined ? DEFAULTS[name] : props[name];
 }
 
-@SBComponent(styles)
+@stylable(styles)
 export class NumberInput extends React.Component<NumberInputProps, NumberInputState> {
     public static defaultProps = {
         onChange: DEFAULTS.onChange,
@@ -152,7 +153,7 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
 
         return (
             <div
-                cssStates={{
+                style-state={{
                     disabled: Boolean(disabled),
                     error: Boolean(error),
                     focus

--- a/src/components/selection-list/selection-list.tsx
+++ b/src/components/selection-list/selection-list.tsx
@@ -1,8 +1,7 @@
 import keycode = require('keycode');
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import {SBComponent} from 'stylable-react-component';
-import {root} from 'wix-react-tools';
+import {properties, stylable} from 'wix-react-tools';
 import {clamp} from '../../utils';
 import listStyle from './selection-list.st.css';
 
@@ -36,23 +35,19 @@ export interface OptionProps {
     focused?: boolean;
 }
 
-@SBComponent(listStyle)
+@stylable(listStyle)
 export class Option extends React.Component<OptionProps, {}> {
     public render() {
-        const props = {
-            cssStates: {
-                disabled: this.props.disabled,
-                selected: this.props.selected,
-                focused:  this.props.focused
-            }
-        };
-
         return (
             <div
                 className="item"
                 data-value={this.props.value}
                 data-disabled={this.props.disabled || undefined}
-                {...props as React.HtmlHTMLAttributes<HTMLDivElement>}
+                style-state={{
+                    disabled: this.props.disabled,
+                    selected: this.props.selected,
+                    focused:  this.props.focused
+                }}
             >
                 {this.props.children}
             </div>
@@ -89,11 +84,9 @@ export interface OptionList {
     renderItem?: (item: SelectionItem) => React.ReactNode;
 }
 
-export interface SelectionListProps extends OptionList {
+export interface SelectionListProps extends OptionList, properties.Props {
     value?: string;
     onChange?: (value: string) => void;
-    style?: any;
-    className?: string;
     tabIndex?: number;
 }
 
@@ -102,7 +95,8 @@ export interface SelectionListState {
     focusedValue?: string;
 }
 
-@SBComponent(listStyle)
+@properties
+@stylable(listStyle)
 export class SelectionList extends React.Component<SelectionListProps, SelectionListState> {
     public static defaultProps: SelectionListProps = {
         tabIndex: -1,
@@ -132,16 +126,10 @@ export class SelectionList extends React.Component<SelectionListProps, Selection
 
         this.focusableItemValues = this.getFocusableItemValuesFromChildren(children);
 
-        const rootProps = root(this.props, {
-            className: 'list',
-            cssStates: {
-                focused: this.state.focused
-            }
-        }) as React.HtmlHTMLAttributes<HTMLDivElement>;
-
         return (
             <div
-                {...rootProps}
+                className="list"
+                style-state={{focused: this.state.focused}}
                 data-automation-id="LIST"
                 onClick={this.handleClick}
                 onKeyDown={this.handleKeyDown}

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import {SBStateless} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
+
 import {ChevronDownIcon, ChevronUpIcon} from '../../icons';
 import buttonStyles from '../../style/default-theme/controls/button.st.css';
 import {noop} from '../../utils';
@@ -12,15 +13,16 @@ export interface StepperProps extends React.HTMLProps<HTMLElement> {
     onDown?: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-export const Stepper: React.StatelessComponent<StepperProps> = SBStateless(
-    ({
+export const Stepper = stylable(styles)<React.SFC<StepperProps>>(props => {
+    const {
         onUp = noop,
         onDown = noop,
         disableUp = false,
         disableDown = false,
-        ...props
-    }) => (
-        <div {...props}>
+        ...rest
+    } = props;
+    return (
+        <div {...rest}>
             <button
                 type="button"
                 tabIndex={-1}
@@ -39,9 +41,8 @@ export const Stepper: React.StatelessComponent<StepperProps> = SBStateless(
                 onClick={onDown}
                 disabled={disableDown}
             >
-                <ChevronDownIcon className="control-icon"/>
+                <ChevronDownIcon className="control-icon" />
             </button>
         </div>
-    ),
-    styles
-);
+    );
+});

--- a/src/components/time-picker/time-picker.tsx
+++ b/src/components/time-picker/time-picker.tsx
@@ -1,6 +1,7 @@
 import * as keycode from 'keycode';
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
+
 import {Stepper} from '../stepper';
 import styles from './time-picker.st.css';
 import {
@@ -51,7 +52,7 @@ function propsValueToSegments(value?: string, format?: Format): {hh?: string, mm
     };
 }
 
-@SBComponent(styles)
+@stylable(styles)
 export class TimePicker extends React.Component<Props, State> {
     public static defaultProps: Partial<Props> = {
         format: is12TimeFormat ? 'ampm' : '24h',
@@ -98,7 +99,7 @@ export class TimePicker extends React.Component<Props, State> {
         return (
             <div
                 data-automation-id="TIME_PICKER"
-                cssStates={{
+                style-state={{
                     focus,
                     disabled: disabled!,
                     empty: !isValueSet
@@ -154,7 +155,7 @@ export class TimePicker extends React.Component<Props, State> {
                         onDown={this.onStepperDown}
                     />
                 }
-                <label className="label" cssStates={{visible: isTouchTimeInputSupported}}>
+                <label className="label" style-state={{visible: isTouchTimeInputSupported}}>
                     <input
                         className="native-input"
                         type="time"

--- a/src/components/toggle/toggle.tsx
+++ b/src/components/toggle/toggle.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
+
 import style from './toggle.st.css';
 
 export interface Props {
@@ -16,7 +17,7 @@ export interface State {
     focus: boolean;
 }
 
-@SBComponent(style)
+@stylable(style)
 export default class Toggle extends React.Component<Props, State> {
     public static defaultProps = {
         checked: false,
@@ -46,7 +47,7 @@ export default class Toggle extends React.Component<Props, State> {
             <label
                 data-automation-id="TOGGLE"
                 onMouseDown={this.onMouseDown}
-                cssStates={{
+                style-state={{
                     checked: checked!,
                     disabled: disabled!,
                     focus: focus!,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4864,9 +4864,9 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
-wix-react-tools@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/wix-react-tools/-/wix-react-tools-2.3.0.tgz#46de1842deb7db96aa3a0217b24fb0ca50f3334e"
+wix-react-tools@3.0.0-1:
+  version "3.0.0-1"
+  resolved "https://registry.yarnpkg.com/wix-react-tools/-/wix-react-tools-3.0.0-1.tgz#08e9b5f527993b791005cf904e15a1d207081124"
   dependencies:
     fp-ts "^0.4.3"
     ifndef "^0.0.31"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4864,9 +4864,9 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
-wix-react-tools@3.0.0-1:
-  version "3.0.0-1"
-  resolved "https://registry.yarnpkg.com/wix-react-tools/-/wix-react-tools-3.0.0-1.tgz#08e9b5f527993b791005cf904e15a1d207081124"
+wix-react-tools@3.0.0-2:
+  version "3.0.0-2"
+  resolved "https://registry.yarnpkg.com/wix-react-tools/-/wix-react-tools-3.0.0-2.tgz#7cecd2a579fce96d1d841cd8a386099517457ef4"
   dependencies:
     fp-ts "^0.4.3"
     ifndef "^0.0.31"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,8 +23,8 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.42.tgz#ab769f51d37646b6fe8d4a086a98c285b1fab3f5"
 
 "@types/node@^8.0.25":
-  version "8.0.25"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.25.tgz#66ecaf4df93f5281b48427ee96fbcdfc4f0cdce1"
+  version "8.0.26"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.26.tgz#4d58be925306fd22b1141085535a0268b8beb189"
 
 "@types/react-dom@^15.5.4":
   version "15.5.4"
@@ -781,11 +781,15 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.0, commander@^2.9.0:
+commander@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
     graceful-readlink ">= 1.0.0"
+
+commander@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
 component-bind@1.0.0:
   version "1.0.0"
@@ -1165,9 +1169,13 @@ di@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/di/-/di-0.0.1.tgz#806649326ceaa7caa3306d75d985ea2748ba913c"
 
-diff@3.2.0, diff@^3.1.0, diff@^3.2.0:
+diff@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
+
+diff@^3.1.0, diff@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
 
 diffie-hellman@^5.0.0:
   version "5.0.2"
@@ -1688,8 +1696,8 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     rimraf "2"
 
 function-bind@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -1970,9 +1978,13 @@ https-proxy-agent@^1.0.0, https-proxy-agent@~1.0.0:
     debug "2"
     extend "3"
 
-iconv-lite@0.4.15, iconv-lite@~0.4.13:
+iconv-lite@0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
+
+iconv-lite@~0.4.13:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
@@ -2692,7 +2704,11 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-"mime-db@>= 1.29.0 < 2", mime-db@~1.29.0:
+"mime-db@>= 1.29.0 < 2":
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
+
+mime-db@~1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.29.0.tgz#48d26d235589651704ac5916ca06001914266878"
 
@@ -2707,8 +2723,8 @@ mime@1.3.4:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
 mime@^1.3.4:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.6.tgz#591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0"
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.0.tgz#69e9e0db51d44f2a3b56e48b7817d7d137f1a343"
 
 mimic-fn@^1.0.0:
   version "1.1.0"
@@ -2813,8 +2829,8 @@ murmurhash@0.0.2, murmurhash@^0.0.2:
   resolved "https://registry.yarnpkg.com/murmurhash/-/murmurhash-0.0.2.tgz#6f07bd8a1105e709c26fc89420cb5930c24585fe"
 
 nan@^2.3.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
 native-promise-only@^0.8.1:
   version "0.8.1"
@@ -3028,7 +3044,7 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@~1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -4265,13 +4281,9 @@ stylable-integration@^5.0.1:
     murmurhash "^0.0.2"
     yargs "^8.0.2"
 
-stylable-react-component@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/stylable-react-component/-/stylable-react-component-1.0.3.tgz#8dd58b352f3b57c0991487e6d00a9dde2109f317"
-
 stylable@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/stylable/-/stylable-4.0.8.tgz#64ddc1e888144463ad2ce2f18ae074d6caf66e92"
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/stylable/-/stylable-4.0.9.tgz#d07875ff522ec1b6bc891698b61f81a7453c1e35"
   dependencies:
     camelcase-css "^1.0.1"
     css-selector-tokenizer "^0.7.0"
@@ -4296,7 +4308,7 @@ stylis@^3.2.3:
   version "3.2.13"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.2.13.tgz#1a5d2ff5ab09f362d6d8065186d526740e9f4f24"
 
-supports-color@3.1.2, supports-color@^3.1.1:
+supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:
@@ -4306,7 +4318,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.2.3:
+supports-color@^3.1.1, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
@@ -4404,11 +4416,17 @@ timers-browserify@^2.0.2:
   dependencies:
     setimmediate "^1.0.4"
 
-tmp@0.0.31, tmp@0.0.x:
+tmp@0.0.31:
   version "0.0.31"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
   dependencies:
     os-tmpdir "~1.0.1"
+
+tmp@0.0.x:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 to-array@0.1.4:
   version "0.1.4"
@@ -4504,8 +4522,8 @@ tsutils@^1.4.0:
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.1.tgz#b9f9ab44e55af9681831d5f28d0aeeaf5c750cb0"
 
 tsutils@^2.8.0, tsutils@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.8.1.tgz#3771404e7ca9f0bedf5d919a47a4b1890a68efff"
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.8.2.tgz#2c1486ba431260845b0ac6f902afd9d708a8ea6a"
   dependencies:
     tslib "^1.7.1"
 
@@ -4846,9 +4864,9 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
-wix-react-tools@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/wix-react-tools/-/wix-react-tools-2.1.0.tgz#1f6a4cb68a12c98546ba7cb273c9689f54c930c6"
+wix-react-tools@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/wix-react-tools/-/wix-react-tools-2.3.0.tgz#46de1842deb7db96aa3a0217b24fb0ca50f3334e"
   dependencies:
     fp-ts "^0.4.3"
     ifndef "^0.0.31"


### PR DESCRIPTION
got rid of stylable-react-component and root function.
Now uses the new properties and stylable decorators exported from wix-react-tools.
Also s/cssStates/style-state per component-guide and new decorator behavior.

**Note: this should fail pending a small fix to `wix-react-tools` regarding cases where `React.createElement` receives `null` props.**

FYI @amir-arad 