### PR TITLE
<Portal /> - Updated a test after the driver change

### DIFF
--- a/test/components/portal.spec.tsx
+++ b/test/components/portal.spec.tsx
@@ -62,24 +62,26 @@ describe('<Portal />', function() {
     });
 
     it('updates the portal content if the children are changed', async function() {
+        const initialText = 'Portal Body';
+        const updatedText = 'Portal Body Updated';
         const {container, result} = clientRenderer.render(
             <Portal>
-                <span>Portal Body</span>
+                <span>{initialText}</span>
             </Portal>
         );
 
         const portal = new PortalTestDriver(result as Portal);
 
-        await waitFor(() => expect(portal.content[0]).to.be.present());
+        await waitFor(() => expect(portal.content[0]).to.have.text(initialText));
 
         clientRenderer.render(
             <Portal>
-                <span>Portal Body Updated</span>
+                <span>{updatedText}</span>
             </Portal>,
             container
         );
 
-        await waitFor(() => expect(portal.content[0]).to.be.present());
+        await waitFor(() => expect(portal.content[0]).to.have.text(updatedText));
     });
 
     it('renders the portal in the bottom of the DOM', async function() {


### PR DESCRIPTION
A test lost some of its meaning after the driver update, this small PR fixes that