### PR TITLE
Upgrade to wix-react-tools v3, and use new decorators

### DIFF
--- a/demo/components-demo.tsx
+++ b/demo/components-demo.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
+
 import ComponentsDemoCSS from './style.st.css';
 
 import {CheckBoxDemo} from './components/checkbox-demo';
@@ -16,7 +17,7 @@ import {TimePickerDemo} from './components/time-picker-demo';
 import {ToggleDemo} from './components/toggle-demo';
 import {TreeViewDemo, TreeViewDemoCustom} from './components/tree-view-demo';
 
-@SBComponent(ComponentsDemoCSS)
+@stylable(ComponentsDemoCSS)
 export class ComponentsDemo extends React.Component {
     public render() {
         return (

--- a/demo/components/checkbox-demo.tsx
+++ b/demo/components/checkbox-demo.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {SBComponent, SBStateless} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import style from './checkbox-demo.st.css';
 
 import {CheckBox, CheckBoxIconProps} from '../../src';
@@ -7,7 +7,7 @@ import {ChangeEvent} from '../../src/types/events';
 
 export const demoCheckBoxText: string = 'Yes, I\'m over 18 years old';
 
-@SBComponent(style)
+@stylable(style)
 export class CheckBoxDemo extends React.Component<{}, {}> {
     public render() {
         return (
@@ -169,7 +169,7 @@ class CustomIconsDemo extends React.Component<{}, {value: boolean}> {
     private handleChange = (e: ChangeEvent<boolean>) => { this.setState({value: e.value}); };
 }
 
-const TickMarkSVG: React.SFC<CheckBoxIconProps> = SBStateless(props => {
+const TickMarkSVG: React.SFC<CheckBoxIconProps> = stylable(style)(props => {
     return (
         <svg
             className="customTickIcon"
@@ -182,9 +182,9 @@ const TickMarkSVG: React.SFC<CheckBoxIconProps> = SBStateless(props => {
             <circle cx="10" cy="14" r="4"/>
         </svg>
     );
-}, style);
+});
 
-const CheckBoxSVG: React.SFC<CheckBoxIconProps> = SBStateless(props => {
+const CheckBoxSVG: React.SFC<CheckBoxIconProps> = stylable(style)(props => {
     return (
         <svg
             className="customBoxIcon"
@@ -195,4 +195,4 @@ const CheckBoxSVG: React.SFC<CheckBoxIconProps> = SBStateless(props => {
             <path d="M 10,1 20,20 1,20 z"/>
         </svg>
     );
-}, style);
+});

--- a/demo/components/modal-demo.tsx
+++ b/demo/components/modal-demo.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {Image, Modal} from '../../src';
 import {RequestCloseEvent} from '../../src/components/modal/modal';
 import styles from './modal-demo.st.css';
@@ -8,7 +8,7 @@ export interface ModalDemoState {
     isOpen: boolean;
 }
 
-@SBComponent(styles)
+@stylable(styles)
 export class ModalDemo extends React.Component<{}, ModalDemoState> {
     public state: ModalDemoState = {
         isOpen: false

--- a/demo/components/number-input.demo.tsx
+++ b/demo/components/number-input.demo.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {NumberInput} from '../../src/components/number-input';
 import styles from './number-input.demo.st.css';
 
@@ -8,7 +8,7 @@ export interface State {
     basicValue?: number;
 }
 
-@SBComponent(styles)
+@stylable(styles)
 export class NumberInputDemo extends React.Component<{}, State> {
 
     constructor() {

--- a/demo/components/popup-demo.tsx
+++ b/demo/components/popup-demo.tsx
@@ -1,5 +1,5 @@
 import React = require('react');
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {Popup, PopupHorizontalPosition, PopupPositionPoint, PopupVerticalPosition, RadioGroup} from '../../src/';
 import {ChangeEvent} from '../../src/types/events';
 import styles from './popup-demo.st.css';
@@ -13,7 +13,7 @@ export interface DemoState {
     aHorizontal: PopupHorizontalPosition;
 }
 
-@SBComponent(styles)
+@stylable(styles)
 export class PopupDemo extends React.Component<{}, DemoState> {
     public state = {
         div: null,

--- a/demo/components/radio-group-demo.tsx
+++ b/demo/components/radio-group-demo.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {RadioButton, RadioGroup} from '../../src';
 import styles from './radio-group-demo.st.css';
 
-@SBComponent(styles)
+@stylable(styles)
 export class RadioGroupDemo extends React.Component<{}, {}> {
     public state = {
         myValue1: 'Start here',

--- a/demo/components/selection-list-demo.tsx
+++ b/demo/components/selection-list-demo.tsx
@@ -1,5 +1,5 @@
 import React = require('react');
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {divider, Option, SelectionList, SelectionListItemValue} from '../../src/components/selection-list';
 import demoStyle from './selection-list-demo.st.css';
 
@@ -46,7 +46,7 @@ export class FoodList extends React.Component {
     private handleChange = ({value}: {value: SelectionListItemValue}) => this.setState({value});
 }
 
-@SBComponent(demoStyle)
+@stylable(demoStyle)
 class EmojiList extends React.Component {
     public state = {value: 'Crocodile'};
     private dataSchema = {value: 'name', label: 'icon'};
@@ -85,7 +85,7 @@ class EmojiList extends React.Component {
     private handleChange = ({value}: {value: SelectionListItemValue}) => this.setState({value});
 }
 
-@SBComponent(demoStyle)
+@stylable(demoStyle)
 class TextStyleList extends React.Component {
     public state = {value: 'heading'};
 

--- a/demo/components/slider-demo.tsx
+++ b/demo/components/slider-demo.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {Slider} from '../../src';
 import {ChangeEvent} from '../../src/types/events';
 import style from './slider-demo.st.css';
@@ -9,7 +9,7 @@ export interface SliderDemoState {
     rawValue: string;
 }
 
-@SBComponent(style)
+@stylable(style)
 export class SliderDemo extends React.Component<{}, SliderDemoState> {
     constructor(props: {}) {
         super(props);

--- a/demo/components/time-picker-demo.tsx
+++ b/demo/components/time-picker-demo.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {TimePicker} from '../../src';
 import {is12TimeFormat} from '../../src/components/time-picker/utils';
 import styles from './time-picker-demo.st.css';
 
-@SBComponent(styles)
+@stylable(styles)
 export class TimePickerDemo extends React.Component<any, any> {
     constructor() {
         super();

--- a/demo/components/tree-view-demo.tsx
+++ b/demo/components/tree-view-demo.tsx
@@ -1,6 +1,6 @@
 import {observer} from 'mobx-react';
 import * as React from 'react';
-import {SBComponent, SBStateless} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {TreeItemData , TreeItemProps, TreeView} from '../../src';
 import style from './tree-view-demo.st.css';
 
@@ -49,7 +49,7 @@ export interface TreeViewDemoCustomState {
 const itemIdPrefix = 'TREE_ITEM';
 
 export const CustomItem: React.SFC<TreeItemProps> =
-    SBStateless(({item, itemRenderer, onItemClick, onIconClick, stateMap}) => {
+    stylable(style)(({item, itemRenderer, onItemClick, onIconClick, stateMap}) => {
         const state = stateMap.getItemState(item);
         const TreeNode = itemRenderer;
         const itemLabel = item.label.replace(' ', '_');
@@ -62,7 +62,7 @@ export const CustomItem: React.SFC<TreeItemProps> =
             <div>
                 <div
                     className="custom-tree-node"
-                    cssStates={{selected: state!.isSelected, focused: state!.isFocused}}
+                    style-state={{selected: state!.isSelected, focused: state!.isFocused}}
                     data-selected={state!.isSelected}
                     data-focused={state!.isFocused}
                     onClick={onItemClick && onItemClick.bind(null, item)}
@@ -91,11 +91,11 @@ export const CustomItem: React.SFC<TreeItemProps> =
                 </div>
             </div>
         );
-    }, style);
+    });
 
 const CustomItemWrapper = observer(CustomItem);
 
-@SBComponent(style)
+@stylable(style)
 export class TreeViewDemo extends React.Component<{}, TreeViewDemoState> {
 
     public state = {selectedItem: undefined, focusedItem: undefined, checkBoxMap: {}};
@@ -134,7 +134,7 @@ export class TreeViewDemo extends React.Component<{}, TreeViewDemoState> {
 
 }
 
-@SBComponent(style)
+@stylable(style)
 export class TreeViewDemoCustom extends React.Component<{}, TreeViewDemoCustomState> {
 
     public state = {selectedItemCustom: undefined, focusedItemCustom: undefined};

--- a/docs/checkbox/readme.md
+++ b/docs/checkbox/readme.md
@@ -26,10 +26,10 @@
 
 ```
 import {CheckBox} from 'stylable-components';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import style from './checkbox-demo.st.css';
 
-@SBComponent(style)
+@stylable(style)
 export class BasicDemo extends React.Component<{}, {value: boolean}> {
     public state = {
         value: false

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "keycode": "^2.1.9",
     "mobx": "^3.2.2",
     "mobx-react": "^4.2.2",
-    "stylable-react-component": "^1.0.3",
-    "wix-react-tools": "2.1.0"
+    "wix-react-tools": "^3.0.0"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.43",

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
-import {root} from 'wix-react-tools';
+import {properties, stylable} from 'wix-react-tools';
 import {FormInputProps} from '../../types/forms';
 import {noop} from '../../utils';
 import styles from './checkbox.st.css';
 
-export interface CheckBoxProps extends FormInputProps<boolean> {
+export interface CheckBoxProps extends FormInputProps<boolean>, properties.Props {
     boxIcon?: React.ComponentType<CheckBoxIconProps>;
     tickIcon?: React.ComponentType<CheckBoxIconProps>;
     indeterminateIcon?: React.ComponentType<CheckBoxIconProps>;
@@ -28,34 +27,31 @@ export interface CheckBoxState {
     isFocused: boolean;
 }
 
-const DefaultCheckBoxSVG: React.SFC<CheckBoxIconProps> = props => {
+const DefaultCheckBoxSVG: React.SFC<CheckBoxIconProps> = properties(props => {
     return (
         <svg
-            {...root(props, {className: ''})}
             xmlns="http://www.w3.org/2000/svg"
             focusable="false"
         >
             <path d="M.5.5h15v15H.5z" />
         </svg>
     );
-};
+});
 
-const DefaultTickMarkSVG: React.SFC<CheckBoxIconProps> = props => {
+const DefaultTickMarkSVG: React.SFC<CheckBoxIconProps> = properties(props => {
     return (
         <svg
-            {...root(props, {className: ''})}
             xmlns="http://www.w3.org/2000/svg"
             focusable="false"
         >
             <path d="M5 8.685l2.496 1.664M8 10.685L11.748 6" />
         </svg>
     );
-};
+});
 
-const DefaultIndeterminateSVG: React.SFC<CheckBoxIconProps> = props => {
+const DefaultIndeterminateSVG: React.SFC<CheckBoxIconProps> = properties(props => {
     return (
         <svg
-            {...root(props, {className: ''})}
             xmlns="http://www.w3.org/2000/svg"
             width="15"
             height="15"
@@ -64,9 +60,10 @@ const DefaultIndeterminateSVG: React.SFC<CheckBoxIconProps> = props => {
             <line x1="4" y1="8" x2="12" y2="8" />
         </svg>
     );
-};
+});
 
-@SBComponent(styles)
+@stylable(styles)
+@properties
 export class CheckBox extends React.Component<CheckBoxProps, CheckBoxState> {
     public static defaultProps: Partial<CheckBoxProps> = {
         boxIcon: DefaultCheckBoxSVG,
@@ -83,11 +80,7 @@ export class CheckBox extends React.Component<CheckBoxProps, CheckBoxState> {
         const BoxIcon = this.props.boxIcon!;
         const IndeterminateIcon = this.props.indeterminateIcon!;
         const TickIcon = this.props.tickIcon!;
-        const rootProps = root(this.props, {
-            'data-automation-id': 'CHECKBOX_ROOT',
-            'className': 'root'
-        });
-        const cssStates = {
+        const styleState = {
             checked: this.props.value!,
             disabled: this.props.disabled!,
             readonly: this.props.readonly!,
@@ -97,9 +90,9 @@ export class CheckBox extends React.Component<CheckBoxProps, CheckBoxState> {
 
         return (
             <div
-                {...rootProps}
+                data-automation-id="CHECKBOX_ROOT"
                 onClick={this.handleChange}
-                cssStates={cssStates}
+                style-state={styleState}
                 role="checkbox"
                 aria-checked={this.props.indeterminate ? 'mixed' : this.props.value}
             >

--- a/src/components/date-picker/calendar.tsx
+++ b/src/components/date-picker/calendar.tsx
@@ -1,7 +1,7 @@
 import {computed} from 'mobx';
 import {observer} from 'mobx-react';
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {
     getDayNames,
     getDaysInMonth,
@@ -26,7 +26,7 @@ export interface CalendarProps {
 
 const monthNames = getMonthNames();
 
-@SBComponent(styles)
+@stylable(styles)
 @observer
 export class Calendar extends React.Component<CalendarProps, {}> {
     public render() {

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -1,7 +1,6 @@
 import * as keycode from 'keycode';
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
-import {root} from 'wix-react-tools';
+import {properties, stylable} from 'wix-react-tools';
 import {FormInputProps} from '../../types/forms';
 import {noop} from '../../utils';
 import {Popup} from '../popup';
@@ -11,7 +10,7 @@ import styles from './date-picker.st.css';
 
 const invalidDate: string = 'Invalid Date';
 
-export interface DatePickerProps extends FormInputProps<Date> {
+export interface DatePickerProps extends FormInputProps<Date>, properties.Props {
     placeholder?: string;
     openOnFocus?: boolean;
     disabled?: boolean;
@@ -30,7 +29,8 @@ export interface DatePickerState {
     highlightFocusedDate: boolean;
 }
 
-@SBComponent(styles)
+@stylable(styles)
+@properties
 export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerState> {
     public static defaultProps: Partial<DatePickerProps> = {
         openOnFocus: true,
@@ -47,16 +47,11 @@ export class DatePicker extends React.PureComponent<DatePickerProps, DatePickerS
     }
 
     public render() {
-        const rootProps = root(this.props, {
-            'data-automation-id': 'DATE_PICKER_ROOT',
-            'className': 'root'
-        }) as React.HTMLAttributes<HTMLDivElement>;
-
         const Icon = this.props.calendarIcon!;
 
         return (
             <div
-                {...rootProps}
+                data-automation-id="DATE_PICKER_ROOT"
                 ref={dropdownRef => this.setState({dropdownRef})}
             >
                 <input

--- a/src/components/date-picker/day.tsx
+++ b/src/components/date-picker/day.tsx
@@ -1,10 +1,9 @@
 import {observer} from 'mobx-react';
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
-import {root} from 'wix-react-tools';
+import {properties, stylable} from 'wix-react-tools';
 import styles from './date-picker.st.css';
 
-export interface DayProps {
+export interface DayProps extends properties.Props {
     day: number;
     selected?: boolean;
     currentDay?: boolean;
@@ -14,11 +13,12 @@ export interface DayProps {
     onSelect?(day: number): void;
 }
 
-@SBComponent(styles)
 @observer
-export class Day extends React.Component<DayProps, {}> {
+@stylable(styles)
+@properties
+export class Day extends React.Component<DayProps> {
     public render() {
-        const cssStates = {
+        const styleState = {
             focused: this.props.focused!,
             selected: this.props.selected!,
             current: this.props.currentDay!,
@@ -27,13 +27,9 @@ export class Day extends React.Component<DayProps, {}> {
 
         return (
             <span
-                {...root(this.props,
-                    {   'data-automation-id': '',
-                        'className': 'calendarItem day'
-                    }) as React.HTMLAttributes<HTMLSpanElement>
-                }
+                className="calendarItem day"
                 onMouseDown={this.onMouseDown}
-                cssStates={cssStates}
+                style-state={styleState}
             >
                 {this.props.day}
             </span>

--- a/src/components/drop-down/drop-down.tsx
+++ b/src/components/drop-down/drop-down.tsx
@@ -1,7 +1,6 @@
 import * as keycode from 'keycode';
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
-import {root} from 'wix-react-tools';
+import {properties, stylable} from 'wix-react-tools';
 import {ChangeEvent} from '../../types/events';
 import {FormInputProps} from '../../types/forms';
 import {noop} from '../../utils/noop';
@@ -18,7 +17,7 @@ const KeyCodes: any = {
     ESC: keycode('escape')
 };
 
-export interface DropDownProps extends OptionList, FormInputProps<string> {
+export interface DropDownProps extends OptionList, FormInputProps<string>, properties.Props {
     open?: boolean;
     disabled?: boolean;
     openOnFocus?: boolean;
@@ -32,7 +31,8 @@ export interface DropDownState {
     open: boolean;
 }
 
-@SBComponent(style)
+@stylable(style)
+@properties
 export class DropDown extends React.PureComponent<DropDownProps, DropDownState> {
     public static defaultProps: DropDownProps = {
         open: false,
@@ -55,16 +55,12 @@ export class DropDown extends React.PureComponent<DropDownProps, DropDownState> 
     }
 
     public render() {
-        const rootProps = root(this.props, {
-            'data-automation-id': 'DROP_DOWN',
-            'className': 'drop-down'
-        });
-
         const ToggleIcon = this.props.toggleIcon!;
 
         return (
             <div
-                {...rootProps}
+                data-automation-id="DROP_DOWN"
+                className="drop-down"
                 onKeyDown={this.onKeyDown}
                 onFocus={this.onFocus}
                 tabIndex={this.props.tabIndex}

--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
-import {root} from 'wix-react-tools';
+import {properties, stylable} from 'wix-react-tools';
 import {noop} from '../../utils';
 import {isElement} from '../../utils/is-element';
 import {enableScrolling, stopScrolling} from '../../utils/stop-scrolling';
@@ -16,8 +15,9 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
     onRequestClose?(event: RequestCloseEvent): void;
 }
 
-@SBComponent(styles)
-export class Modal extends React.PureComponent<ModalProps, {}> {
+@stylable(styles)
+@properties
+export class Modal extends React.PureComponent<ModalProps> {
     public static defaultProps: ModalProps = {
         isOpen: false,
         onRequestClose: noop
@@ -32,13 +32,9 @@ export class Modal extends React.PureComponent<ModalProps, {}> {
     }
 
     public render() {
-        const rootProps = root(this.props, {
-            className: 'root'
-        });
-
         return (
             this.props.isOpen ? (
-                <Portal {...rootProps}>
+                <Portal>
                     <div className="backdrop" data-slot="backdrop" data-automation-id="MODAL" onClick={this.onClick}>
                         <div className="children" data-slot="children">
                             {this.props.children}

--- a/src/components/number-input/number-input.tsx
+++ b/src/components/number-input/number-input.tsx
@@ -1,6 +1,6 @@
 import {codes as KeyCodes} from 'keycode';
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {isNumber, noop} from '../../utils';
 import {Modifiers, Stepper} from '../stepper';
 import styles from './number-input.st.css';
@@ -93,7 +93,7 @@ function getPropWithDefault<Prop extends keyof NumberInputProps & keyof DefaultP
     return props[name] === undefined ? DEFAULTS[name] : props[name];
 }
 
-@SBComponent(styles)
+@stylable(styles)
 export class NumberInput extends React.Component<NumberInputProps, NumberInputState> {
     public static defaultProps = {
         onChange: DEFAULTS.onChange,
@@ -151,7 +151,7 @@ export class NumberInput extends React.Component<NumberInputProps, NumberInputSt
 
         return (
             <div
-                cssStates={{
+                style-state={{
                     disabled: Boolean(disabled),
                     error: Boolean(error),
                     focus

--- a/src/components/popup/popup.tsx
+++ b/src/components/popup/popup.tsx
@@ -22,7 +22,7 @@ export interface PopupCompProps extends PopupProps {
     anchor: Element | null;
 }
 
-export class Popup extends React.Component<PopupCompProps, {}> {
+export class Popup extends React.Component<PopupCompProps> {
     public static defaultProps: Partial<PopupCompProps> = {
         open: false,
         anchorPosition: {vertical: 'bottom', horizontal: 'left'},

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import {root} from 'wix-react-tools';
 
 export interface PortalProps extends React.HTMLAttributes<HTMLDivElement> {
     children: React.ReactNode;
@@ -11,13 +10,8 @@ export class Portal extends React.PureComponent<PortalProps, {}> {
     private portalContent: React.ReactElement<React.HTMLAttributes<HTMLDivElement>>;
 
     public render() {
-        const rootProps = root(this.props, {
-            'data-automation-id': 'PORTAL',
-            'className': ''
-        });
-
         this.portalContent = (
-            <div {...rootProps}>
+            <div data-automation-id="PORTAL" className={this.props.className} style={this.props.style}>
                 {this.props.children}
             </div>
         );

--- a/src/components/radio-group/radio-button.tsx
+++ b/src/components/radio-group/radio-button.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
-import {root} from 'wix-react-tools';
+import {properties, stylable} from 'wix-react-tools';
 import {FormInputProps} from '../../types/forms';
 import {noop} from '../../utils';
 import style from './radio-button.st.css';
@@ -19,7 +18,8 @@ export interface RadioButtonState {
     isFocused: boolean;
 }
 
-@SBComponent(style)
+@stylable(style)
+@properties
 export class RadioButton extends React.Component<RadioButtonProps, RadioButtonState> {
     public static defaultProps: Partial<RadioButtonProps> = {
         onChange: noop,
@@ -31,12 +31,7 @@ export class RadioButton extends React.Component<RadioButtonProps, RadioButtonSt
     public state: RadioButtonState = {isFocused: false};
 
     public render() {
-        const rootProps = root(this.props, {
-            className: '',
-            ['data-automation-id']: 'RADIO_BUTTON_ROOT'
-        });
-
-        const cssStates = {
+        const styleState = {
             checked: this.props.checked,
             disabled: this.props.disabled,
             isLeftLabel: this.props.labelLocation === 'left',
@@ -45,9 +40,9 @@ export class RadioButton extends React.Component<RadioButtonProps, RadioButtonSt
 
         return (
             <div
-                {...rootProps}
+                data-automation-id="RADIO_BUTTON_ROOT"
                 onClick={this.onChange}
-                cssStates={cssStates}
+                style-state={styleState}
                 role="radio"
                 aria-checked={this.props.checked}
             >
@@ -79,7 +74,7 @@ export class RadioButton extends React.Component<RadioButtonProps, RadioButtonSt
         );
     }
 
-    private onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    private onChange = (e: React.SyntheticEvent<HTMLElement>) => {
         if (!this.props.disabled && !this.props.readOnly) {
             this.props.onChange!({value: this.props.value!});
         }

--- a/src/components/radio-group/radio-group.tsx
+++ b/src/components/radio-group/radio-group.tsx
@@ -1,14 +1,13 @@
 import {action, computed, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
-import {root} from 'wix-react-tools';
+import {properties, stylable} from 'wix-react-tools';
 import {ChangeEvent} from '../../types/events';
 import {FormInputProps} from '../../types/forms';
 import {RadioButton, RadioButtonProps} from './radio-button';
 import styles from './radio-group.st.css';
 
-export interface RadioGroupProps extends FormInputProps<string> {
+export interface RadioGroupProps extends FormInputProps<string>, properties.Props {
     children?: any;
     dataSource?: RadioButtonProps[];
     labelLocation?: 'right' | 'left';
@@ -25,11 +24,13 @@ export interface RadioState {
     checked: boolean;
 }
 
-@SBComponent(styles) @observer
-export class RadioGroup extends React.Component<RadioGroupProps, {}> {
-    public static defaultProps = {
+@stylable(styles)
+@properties
+@observer
+export class RadioGroup extends React.Component<RadioGroupProps> {
+    public static defaultProps: Partial<RadioGroupProps> = {
         dataSource: [],
-        location: 'right',
+        labelLocation: 'right',
         tabIndex: 0
     };
 
@@ -60,13 +61,8 @@ export class RadioGroup extends React.Component<RadioGroupProps, {}> {
             childArray = this.createChildrenFromDataSource();
         }
 
-        const rootProps = root(this.props, {
-            'className': 'root',
-            'data-automation-id': 'RADIO_GROUP'
-        });
-
         return (
-            <div {...rootProps} role="radiogroup">
+            <div data-automation-id="RADIO_GROUP" role="radiogroup">
                 {childArray}
             </div>
         );

--- a/src/components/screen-reader-notification/screen-reader-notification.tsx
+++ b/src/components/screen-reader-notification/screen-reader-notification.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import {SBStateless} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import styles from './screen-reader-notification.st.css';
 
-export const ScreenReaderNotification: React.SFC = SBStateless(
-    ({children}: {children: React.ReactNode}) => {
+export const ScreenReaderNotification: React.SFC =
+    stylable(styles)(({children}: {children: React.ReactNode}) => {
         return (
             <p
                 data-automation-id="SCREEN_READER_NOTIFICATION"
@@ -11,6 +11,4 @@ export const ScreenReaderNotification: React.SFC = SBStateless(
                 children={children}
             />
         );
-    },
-    styles
-);
+});

--- a/src/components/selection-list/divider.tsx
+++ b/src/components/selection-list/divider.tsx
@@ -1,10 +1,9 @@
 import React = require('react');
-import {SBStateless} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import listStyle from './selection-list.st.css';
 
 export const divider = Symbol('divider');
 
-export const Divider: React.SFC = SBStateless(
-    () => <div className="divider" data-automation-id="DIVIDER" />,
-    listStyle
+export const Divider: React.SFC = stylable(listStyle)(
+    () => <div className="divider" data-automation-id="DIVIDER" />
 );

--- a/src/components/selection-list/option.tsx
+++ b/src/components/selection-list/option.tsx
@@ -1,5 +1,5 @@
 import React = require('react');
-import {SBStateless} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {SelectionListItemValue} from './selection-list-model';
 import listStyle from './selection-list.st.css';
 
@@ -11,12 +11,12 @@ export interface OptionProps {
     value?: SelectionListItemValue;
 }
 
-export const Option: React.SFC<OptionProps> = SBStateless(
+export const Option: React.SFC<OptionProps> = stylable(listStyle)(
     props => (
         <div
             className="item"
             data-value={props.disabled ? undefined : props.value}
-            cssStates={{
+            style-state={{
                 disabled: Boolean(props.disabled),
                 selected: Boolean(props.selected),
                 focused:  Boolean(props.focused)
@@ -24,6 +24,5 @@ export const Option: React.SFC<OptionProps> = SBStateless(
         >
             {props.children}
         </div>
-    ),
-    listStyle
+    )
 );

--- a/src/components/selection-list/selection-list-view.tsx
+++ b/src/components/selection-list/selection-list-view.tsx
@@ -1,7 +1,6 @@
 import {observer} from 'mobx-react';
 import React = require('react');
-import {SBComponent} from 'stylable-react-component';
-import {root} from 'wix-react-tools';
+import {properties, stylable} from 'wix-react-tools';
 import {ChangeEvent} from '../../types/events';
 import {FormInputProps} from '../../types/forms';
 import {noop} from '../../utils';
@@ -32,9 +31,10 @@ export interface ViewProps extends FormInputProps<SelectionListItemValue> {
 }
 
 @observer
-@SBComponent(listStyle)
+@stylable(listStyle)
+@properties
 export class SelectionListView extends React.Component<ViewProps> {
-    public static defaultProps = {
+    public static defaultProps: Partial<ViewProps> = {
         onChange: noop,
         onBlur: noop,
         onFocus: noop,
@@ -44,8 +44,9 @@ export class SelectionListView extends React.Component<ViewProps> {
     public render() {
         return (
             <div
-                {...root(this.props, {'className': 'list', 'data-automation-id': 'LIST'})}
-                cssStates={{focused: Boolean(this.props.focused)}}
+                className="list"
+                data-automation-id="LIST"
+                style-state={{focused: Boolean(this.props.focused)}}
                 onBlur={this.props.onBlur}
                 onClick={this.handleClick}
                 onFocus={this.props.onFocus}

--- a/src/components/selection-list/selection-list.tsx
+++ b/src/components/selection-list/selection-list.tsx
@@ -2,7 +2,7 @@ import keycode = require('keycode');
 import {autorun, computed, observable, untracked} from 'mobx';
 import {observer} from 'mobx-react';
 import React = require('react');
-import {Disposers, root} from 'wix-react-tools';
+import {Disposers, properties} from 'wix-react-tools';
 import {ChangeEvent} from '../../types/events';
 import {FormInputProps} from '../../types/forms';
 import {noop} from '../../utils';
@@ -18,6 +18,7 @@ export interface Props extends OptionList, FormInputProps<SelectionListItemValue
 }
 
 @observer
+@properties
 export class SelectionList extends React.Component<Props> {
     public static defaultProps: Props = {
         onChange: noop,
@@ -59,7 +60,6 @@ export class SelectionList extends React.Component<Props> {
     public render() {
         return (
             <SelectionListView
-                {...root(this.props, {className: ''})}
                 focused={this.focused}
                 list={this.list}
                 onBlur={this.handleBlur}

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -1,13 +1,12 @@
 import * as keycode from 'keycode';
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
-import {root} from 'wix-react-tools';
+import {properties, stylable} from 'wix-react-tools';
 import {GlobalEvent} from '../global-event';
 import {FormInputProps} from './../../types/forms';
 import {noop} from './../../utils/noop';
 import style from './slider.st.css';
 
-const AXISES = {
+const AXISES: {[name: string]: AxisOptions} = {
     x: 'x',
     y: 'y',
     xReverse: 'x-reverse',
@@ -32,7 +31,7 @@ export interface PointerPosition {
     clientX: number;
     clientY: number;
 }
-export interface SliderProps extends FormInputProps<number, string> {
+export interface SliderProps extends FormInputProps<number, string>, properties.Props {
     tooltip?: React.ReactNode;
 
     min?: number;
@@ -63,9 +62,10 @@ export interface SliderState {
     isReverse: boolean;
 }
 
-@SBComponent(style)
+@stylable(style)
+@properties
 export class Slider extends React.Component<SliderProps, SliderState> {
-    public static defaultProps = {
+    public static defaultProps: Partial<SliderProps> = {
         min: DEFAULT_MIN,
         max: DEFAULT_MAX,
         step: DEFAULT_STEP,
@@ -107,11 +107,9 @@ export class Slider extends React.Component<SliderProps, SliderState> {
     public render() {
         return (
             <div
-                {...root(this.props, {
-                    'data-automation-id': 'SLIDER-CONTAINER',
-                    'className': 'container'
-                })}
-                cssStates={{
+                data-automation-id="SLIDER-CONTAINER"
+                className="container"
+                style-state={{
                     'active': this.state.isActive,
                     'disabled': Boolean(this.props.disabled),
                     'error': Boolean(this.props.error),

--- a/src/components/stepper/stepper.tsx
+++ b/src/components/stepper/stepper.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {ChevronDownIcon, ChevronUpIcon} from '../../icons';
 import buttonStyles from '../../style/default-theme/controls/button.st.css';
 import {GlobalEvent} from '../global-event';
@@ -34,7 +34,7 @@ const DEFAULTS = {
     disableDown: false
 };
 
-@SBComponent(styles)
+@stylable(styles)
 export class Stepper extends React.Component<StepperProps, State> {
     public static defaultProps = {
         disableUp: DEFAULTS.disableUp,

--- a/src/components/time-picker/time-picker.tsx
+++ b/src/components/time-picker/time-picker.tsx
@@ -1,6 +1,6 @@
 import * as keycode from 'keycode';
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {ScreenReaderNotification} from '../screen-reader-notification';
 import {Modifiers, Stepper} from '../stepper';
 import {LABELS} from './strings';
@@ -57,7 +57,7 @@ function propsValueToSegments(value?: string, format?: Format): {hh?: string, mm
     };
 }
 
-@SBComponent(styles)
+@stylable(styles)
 export class TimePicker extends React.Component<Props, State> {
     public static defaultProps: Partial<Props> = {
         format: is12TimeFormat ? 'ampm' : '24h',
@@ -107,13 +107,13 @@ export class TimePicker extends React.Component<Props, State> {
         return (
             <div
                 data-automation-id="TIME_PICKER"
-                cssStates={{
+                style-state={{
                     focus,
                     'error': error!,
                     'disabled': disabled!,
                     'empty': !isValueSet,
                     'rtl': rtl!,
-                    'has-placeholder': Boolean(placeholder)
+                    'has-placeholder': !!placeholder
                 }}
                 onMouseDown={this.onRootMouseDown}
             >
@@ -181,7 +181,7 @@ export class TimePicker extends React.Component<Props, State> {
                         />
                     </div>
                 }
-                <label className="label" cssStates={{visible: isTouchTimeInputSupported}}>
+                <label className="label" style-state={{visible: isTouchTimeInputSupported}}>
                     <input
                         className="native-input"
                         type="time"

--- a/src/components/toggle/toggle.tsx
+++ b/src/components/toggle/toggle.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {SBComponent} from 'stylable-react-component';
+import {stylable} from 'wix-react-tools';
 import {FormInputProps} from '../../types/forms';
 import style from './toggle.st.css';
 
@@ -17,7 +17,7 @@ export interface State {
     focus: boolean;
 }
 
-@SBComponent(style)
+@stylable(style)
 export default class Toggle extends React.Component<Props, State> {
     public static defaultProps = {
         value: false,
@@ -50,7 +50,7 @@ export default class Toggle extends React.Component<Props, State> {
             <label
                 data-automation-id="TOGGLE"
                 onMouseDown={this.onMouseDown}
-                cssStates={{
+                style-state={{
                     checked: value!,
                     disabled: disabled!,
                     focus: focus!,

--- a/src/components/tree-view/tree-view.tsx
+++ b/src/components/tree-view/tree-view.tsx
@@ -1,12 +1,11 @@
+import * as keycode from 'keycode';
 import {action, autorun, observable} from 'mobx';
 import {observer} from 'mobx-react';
 import * as React from 'react';
-import {root} from 'wix-react-tools';
-import {getLastAvailableItem, getNextItem, getPreviousItem} from './tree-util';
+import {properties, stylable} from 'wix-react-tools';
 
-import * as keycode from 'keycode';
-import {SBComponent, SBStateless} from 'stylable-react-component';
 import nodeStyle from './tree-node.st.css';
+import {getLastAvailableItem, getNextItem, getPreviousItem} from './tree-util';
 import {MinusIcon, PlusIcon} from './tree-view-icons';
 import style from './tree-view.st.css';
 
@@ -70,7 +69,7 @@ function getFocusedItemKey(item: TreeItemData) {
 }
 
 export const TreeItem: React.SFC<TreeItemProps> =
-    SBStateless(({item, itemRenderer, onItemClick, onIconClick, stateMap}) => {
+    stylable(nodeStyle)(({item, itemRenderer, onItemClick, onIconClick, stateMap}) => {
         const state = stateMap.getItemState(item);
         const itemLabel = item.label.replace(' ', '_');
         const TreeNode = itemRenderer;
@@ -92,7 +91,7 @@ export const TreeItem: React.SFC<TreeItemProps> =
                 <div
                     data-automation-id={`${itemIdPrefix}_${itemLabel}`}
                     className="tree-node"
-                    cssStates={{selected: state!.isSelected, focused: state!.isFocused}}
+                    style-state={{selected: state!.isSelected, focused: state!.isFocused}}
                     data-selected={state!.isSelected}
                     data-focused={state!.isFocused}
                     onClick={onItemClick && onItemClick.bind(null, item)}
@@ -121,7 +120,7 @@ export const TreeItem: React.SFC<TreeItemProps> =
                 </ul>}
             </li>
         );
-    }, nodeStyle);
+    });
 
 const TreeItemWrapper = observer(TreeItem);
 
@@ -140,8 +139,10 @@ export class TreeStateMap {
     }
 }
 
-@SBComponent(style) @observer
-export class TreeView extends React.Component<TreeViewProps, {}> {
+@observer
+@stylable(style)
+@properties
+export class TreeView extends React.Component<TreeViewProps> {
     public static defaultProps: Partial<TreeViewProps> = {
         itemRenderer: TreeItemWrapper,
         onSelectItem: () => { },
@@ -169,11 +170,10 @@ export class TreeView extends React.Component<TreeViewProps, {}> {
 
     public render() {
         const TreeNode = this.props.itemRenderer!;
-        const rootProps = root(this.props, {'data-automation-id': 'TREE_VIEW', 'className': ''});
 
         return (
             <ul
-                {...rootProps}
+                data-automation-id="TREE_VIEW"
                 onKeyDown={this.onKeyDown}
                 role="tree"
                 tabIndex={0}

--- a/test/components/time-picker.spec.tsx
+++ b/test/components/time-picker.spec.tsx
@@ -74,7 +74,7 @@ describe('<TimePicker/>', () => {
         });
     });
 
-    describe.only('render with value="4:36" format="ampm"', () => {
+    describe('render with value="4:36" format="ampm"', () => {
         let renderer: any;
         let hh: any;
         let mm: any;

--- a/test/components/time-picker.spec.tsx
+++ b/test/components/time-picker.spec.tsx
@@ -74,13 +74,13 @@ describe('<TimePicker/>', () => {
         });
     });
 
-    describe('render with value="4:36" format="ampm"', () => {
+    describe.only('render with value="4:36" format="ampm"', () => {
         let renderer: any;
         let hh: any;
         let mm: any;
         let ampm: any;
         beforeEach(() => {
-            renderer = clientRenderer.render(<TimePicker value="4:36"/>);
+            renderer = clientRenderer.render(<TimePicker value="4:36" format="ampm" />);
             hh = renderer.select('TIME_PICKER_INPUT_HH');
             mm = renderer.select('TIME_PICKER_INPUT_MM');
             ampm = renderer.select('TIME_PICKER_AMPM');

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,8 +44,8 @@
     "@types/sinon" "*"
 
 "@types/sinon@*", "@types/sinon@^2.3.3":
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-2.3.3.tgz#1f20b96f954b4997a09c1c0a20264aaba6b00147"
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-2.3.4.tgz#2b3aa82dfc791eeff1d970b657a77eafff2899ff"
 
 "@types/webpack-env@^1.13.1":
   version "1.13.1"
@@ -871,8 +871,8 @@ content-disposition@0.5.2:
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
 content-type@~1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.3.tgz#da18ef2fb64ca6acc905cc72017d3f38185b91d1"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -1683,10 +1683,6 @@ forwarded@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.1.tgz#8a4e30c640b05395399a3549c730257728048961"
 
-fp-ts@^0.4.3:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-0.4.6.tgz#43934cf5ae405e6a4726f1f6d216ea1c985672e8"
-
 fresh@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.0.tgz#f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e"
@@ -1975,6 +1971,10 @@ http-errors@1.6.2, http-errors@~1.6.1, http-errors@~1.6.2:
     inherits "2.0.3"
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
+
+http-parser-js@>=0.4.0:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.5.tgz#a3ecf39a667481a38ca60882ab57a2db578b9970"
 
 http-proxy-middleware@~0.17.4:
   version "0.17.4"
@@ -2292,8 +2292,8 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
 js-base64@^2.1.9:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.2.0.tgz#5e8a8d193a908198dd23d1704826d207b0e5a8f6"
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.3.1.tgz#3705897c35fce0e202132630e750d8a17cd220ec"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -2629,8 +2629,8 @@ log4js@^0.6.31:
     semver "~4.3.3"
 
 loglevel@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.4.1.tgz#95b383f91a3c2756fd4ab093667e4309161f2bcd"
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.5.0.tgz#3863984a2c326b986fbb965f378758a6dc8a4324"
 
 lolex@^1.6.0:
   version "1.6.0"
@@ -2834,8 +2834,8 @@ mocha-loader@^1.1.1:
     style-loader "~0.13.1"
 
 mocha@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.2.tgz#3d5585cc6bd9e43a7c0bd251631abc0fbea0f032"
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-3.5.3.tgz#1e0480fe36d2da5858d1eb6acc38418b26eaa20d"
   dependencies:
     browser-stdout "1.3.0"
     commander "2.9.0"
@@ -3128,8 +3128,8 @@ p-locate@^2.0.0:
     p-limit "^1.1.0"
 
 p-map@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.1.1.tgz#05f5e4ae97a068371bc2a5cc86bfbdbc19c4ae7a"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
 pako@~0.2.0:
   version "0.2.9"
@@ -3927,8 +3927,8 @@ right-align@^0.1.1:
     align-text "^0.1.1"
 
 rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
 
@@ -4352,10 +4352,6 @@ stylable-integration@^5.1.3:
     murmurhash "^0.0.2"
     webpack-sources "^1.0.1"
     yargs "^8.0.2"
-
-stylable-react-component@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/stylable-react-component/-/stylable-react-component-1.0.3.tgz#8dd58b352f3b57c0991487e6d00a9dde2109f317"
 
 stylable@^4.0.12:
   version "4.0.12"
@@ -4911,9 +4907,10 @@ webpack@^3.5.6:
     yargs "^8.0.2"
 
 websocket-driver@>=0.5.1:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.6.5.tgz#5cb2556ceb85f4373c6d8238aa691c8454e13a36"
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.0.tgz#0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb"
   dependencies:
+    http-parser-js ">=0.4.0"
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:
@@ -4952,11 +4949,10 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
-wix-react-tools@2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/wix-react-tools/-/wix-react-tools-2.1.0.tgz#1f6a4cb68a12c98546ba7cb273c9689f54c930c6"
+wix-react-tools@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/wix-react-tools/-/wix-react-tools-3.0.0.tgz#3ba84c5d14ae3d28447508ae31972b46eab642c3"
   dependencies:
-    fp-ts "^0.4.3"
     ifndef "^0.0.31"
     lodash "^4.17.4"
     memoize-weak "^1.0.1"


### PR DESCRIPTION
got rid of stylable-react-component and root function.
Now uses the new properties and stylable decorators exported from wix-react-tools.
Also s/cssStates/style-state per component-guide and new decorator behavior.