### PR TITLE
<Portal /> now passes props to target

### DIFF
--- a/src/components/popup/popup.tsx
+++ b/src/components/popup/popup.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {properties} from 'wix-react-tools';
 import {Portal} from '../portal';
 
 export type PopupVerticalPosition =  'top' | 'center' | 'bottom';
@@ -9,7 +10,7 @@ export interface PopupPositionPoint {
     horizontal: PopupHorizontalPosition;
 }
 
-export interface PopupProps {
+export interface PopupProps extends properties.Props {
     open?: boolean;
     anchorPosition?: PopupPositionPoint;
     popupPosition?: PopupPositionPoint;
@@ -22,6 +23,7 @@ export interface PopupCompProps extends PopupProps {
     anchor: Element | null;
 }
 
+@properties
 export class Popup extends React.Component<PopupCompProps> {
     public static defaultProps: Partial<PopupCompProps> = {
         open: false,

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -5,17 +5,15 @@ export interface PortalProps extends React.HTMLAttributes<HTMLDivElement> {
     children: React.ReactNode;
 }
 
-export class Portal extends React.PureComponent<PortalProps, {}> {
+export class Portal extends React.PureComponent<PortalProps> {
     private container: HTMLDivElement | null;
     private portalContent: React.ReactElement<React.HTMLAttributes<HTMLDivElement>>;
 
     public render() {
+        const {children, ...rest} = this.props;
         this.portalContent = (
-            <div data-automation-id="PORTAL" className={this.props.className} style={this.props.style}>
-                {this.props.children}
-            </div>
+            <div {...rest} data-automation-id="PORTAL">{children}</div>
         );
-
         return null;
     }
 

--- a/test/components/portal.spec.tsx
+++ b/test/components/portal.spec.tsx
@@ -44,6 +44,29 @@ describe('<Portal />', function() {
         await waitFor(() => expect(portal.root).to.have.nested.property('style.position', 'fixed'));
     });
 
+    it('applies supplied className and id to the popup and updates them if changed', async function() {
+        const {container, result} = clientRenderer.render(
+            <Portal className="my-test-class" id="my-test-id">
+                <span>Portal Body</span>
+            </Portal>
+        );
+
+        const portal = new PortalTestDriver(result as Portal);
+
+        await waitFor(() => expect(portal.root).to.have.nested.property('className', 'my-test-class'));
+        await waitFor(() => expect(portal.root).to.have.nested.property('id', 'my-test-id'));
+
+        clientRenderer.render(
+            <Portal className="another-test-class" id="another-test-id">
+                <span>Portal Body</span>
+            </Portal>,
+            container
+        );
+
+        await waitFor(() => expect(portal.root).to.have.nested.property('className', 'another-test-class'));
+        await waitFor(() => expect(portal.root).to.have.nested.property('id', 'another-test-id'));
+    });
+
     it('removes the component when unmounting', async function() {
         const container = document.body.appendChild(document.createElement('div'));
         const {result} = clientRenderer.render(


### PR DESCRIPTION
Its interface extended `React.HTMLAttributes<HTMLDivElement>`, but never passed these props on.

In addition, Popup now uses the @properties decorator.