### PR TITLE
Modal: Fix SyntheticEvent warning by React

### DIFF
--- a/src/components/modal/modal.tsx
+++ b/src/components/modal/modal.tsx
@@ -45,11 +45,10 @@ export class Modal extends React.PureComponent<ModalProps> {
         );
     }
 
-    private onClick: React.EventHandler<React.MouseEvent<HTMLDivElement>> = event => {
-        const closeEvent: RequestCloseEvent = Object.create(event);
+    private onClick: React.EventHandler<React.SyntheticEvent<Element>> = event => {
         const {target} = event;
         if (isElement(target)) {
-            closeEvent.source = this.getDataFromNearestNode(target);
+            const closeEvent: RequestCloseEvent = {...event, source: this.getDataFromNearestNode(target)};
             this.props.onRequestClose!(closeEvent);
         }
     }


### PR DESCRIPTION
React re-uses the synthetic-event objects, so one should not extend them and pass to user.