### PR TITLE
Infrastructure changes and small cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
+# stylable-components
 lib
 dist
 .idea
 .vscode
+.history
+.DS_Store
 
 # Logs
 logs
@@ -34,12 +37,15 @@ bower_components
 # node-waf configuration
 .lock-wscript
 
-# Compiled binary addons (http://nodejs.org/api/addons.html)
+# Compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release
 
 # Dependency directories
 node_modules/
 jspm_packages/
+
+# Typescript v1 declaration files
+typings/
 
 # Optional npm cache directory
 .npm
@@ -58,6 +64,3 @@ jspm_packages/
 
 # dotenv environment variables file
 .env
-
-.history
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 lib
+dist
 .idea
 .vscode
 

--- a/custom-typings/stylable.d.ts
+++ b/custom-typings/stylable.d.ts
@@ -1,5 +1,5 @@
 // Here so that we can: import style from '[path-to].st.css'
-declare module '*.css' {
+declare module '*.st.css' {
     const content: any;
     export default content;
 }

--- a/package.json
+++ b/package.json
@@ -65,8 +65,6 @@
   "files": [
     "dist/src",
     "dist/test-kit",
-    "src",
-    "test-kit",
     "custom-typings"
   ],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "dist/test-kit",
     "src",
     "test-kit",
-    "typings"
+    "custom-typings"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "stylable-components",
   "version": "0.2.0-0",
   "description": "Fully-tested & strictly-typed component library based on React, using optional Wix styling.",
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
   "scripts": {
-    "clean": "rimraf ./lib",
-    "build": "tsc -d --p tsconfig.publish.json && stc --srcDir=src --outDir=lib --diagnostics",
+    "clean": "rimraf ./dist ./lib",
+    "build": "tsc && stc --srcDir=src --outDir=dist/src --diagnostics",
     "prepublish": "npm run lint && npm run build",
     "lint": "npm run lint:src && npm run lint:demo && npm run lint:test",
     "lint:src": "tslint \"src/**/*.ts?(x)\" -c tslint.json --type-check -p tsconfig.json --fix",
@@ -63,8 +63,10 @@
   "testGlob": "./test/**/*.spec.ts?(x)",
   "license": "MIT",
   "files": [
-    "lib",
+    "dist/src",
+    "dist/test-kit",
     "src",
+    "test-kit",
     "typings"
   ],
   "repository": {

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -1,5 +1,6 @@
 import * as keycode from 'keycode';
 import * as React from 'react';
+import * as PropTypes from 'prop-types';
 import {properties, stylable} from 'wix-react-tools';
 import {isRTLContext} from '../../utils';
 import {GlobalEvent} from '../global-event';
@@ -85,8 +86,8 @@ export class Slider extends React.Component<SliderProps, SliderState> {
     };
 
     public static contextTypes = {
-        contextProvider: React.PropTypes.shape({
-            dir: React.PropTypes.string
+        contextProvider: PropTypes.shape({
+            dir: PropTypes.string
         })
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-/// <reference path="../typings/stylable.d.ts" />
+/// <reference path="../custom-typings/stylable.d.ts" />
 export * from './components';
 export * from './icons';
 export * from './types';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,7 +47,7 @@
     // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    "inlineSources": true,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
     "experimentalDecorators": true        /* Enables experimental support for ES7 decorators. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,10 +13,10 @@
     "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     "sourceMap": true,                        /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./lib",                        /* Redirect output structure to the directory. */
+    "outDir": "./dist",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "removeComments": true,                /* Do not emit comments to output. */
-    "noEmit": true,                           /* Do not emit outputs. */
+    // "noEmit": false,                       /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */

--- a/tsconfig.publish.json
+++ b/tsconfig.publish.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig",
-  "compilerOptions": {
-    "noEmit": false
-  },
-  "include": [
-    "src"
-  ]
-}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = {
                 loader: 'ts-loader',
                 options: {
                     compilerOptions: {
-                        "noEmit": false
+                        "declaration": false
                     }
                 }
             },


### PR DESCRIPTION
- Build to `dist` instead of `lib`. Directory name was changed for better alignment with configuration of our other libraries (`stylable`, `wix-react-tools`, etc).
- Removed separate typescript publish config, as the entire pattern seems to be very fragile (adding test-kit broke the entire file tree). There is now a single `tsconfig` file, and running `tsc` in terminal will emit files as well.
- `dist` now contains all source roots (`src`, `test`, `test-kit`, and `demo`), which causes an additional depth of directories (`dist/src/index.js` instead of `dist/index.js`). `stc` command line was adjusted for the change as well.
- Renamed `typings` to `custom-typings`, as the default `.gitignore` GitHub provides ignores it.
- Changed custom global stylable type to target only `.st.css` files (instead of all `.css`). This declaration is linked to by the library's index, so it affects any ts projects using `stylable-components`.
- Fixed react warning in slider due to using React.PropTypes, instead of the now-separate prop-types package for better forward compatibility with react 16.
- Update gitignore to latest version, with custom ignored stuff at the top (marked as such). https://github.com/github/gitignore/blob/master/Node.gitignore
- published target now includes test-kit (and its sources for source-maps)
- `webpack` configuration now forces ts-loader to not generate `.d.ts` files, which makes working with `webpack-dev-server` a bit easier (no longer lists these files). Declaration generation errors are still being caught by `build` and IDEs (both who use the main `tsconfig.json`).
- Building now includes the sources in the `.js.map` files, instead of published target including the original `src` and `test-kit` folders. Will ensure user projects don't includes the sources directly. `webpack` loads and maps these properly.