### PR TITLE
revert external hiddenElement composition for checkbox and radio

### DIFF
--- a/src/components/checkbox/checkbox.st.css
+++ b/src/components/checkbox/checkbox.st.css
@@ -1,10 +1,5 @@
 @namespace "CheckBox";
 
-:import {
-    -st-from: '../../style/project.st.css';
-    -st-named: hiddenElement;
-}
-
 .root {
     -st-states: checked, disabled, indeterminate, readonly, focus;
     display: inline-block;
@@ -55,7 +50,14 @@
 }
 
 .nativeCheckbox {
-    -st-compose: hiddenElement;
+    position: absolute;
+    overflow: hidden;
+    height: 1px;
+    width: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    opacity: 0;
 }
 
 .childContainer {

--- a/src/components/radio-group/radio-button.st.css
+++ b/src/components/radio-group/radio-button.st.css
@@ -2,7 +2,7 @@
 
 :import {
     -st-from: '../../style/project.st.css';
-    -st-named: B5, B6, B7, M3, PR3, hiddenElement;
+    -st-named: B5, B6, B7, M3, PR3;
 }
 
 :vars {
@@ -32,7 +32,14 @@
 }
 
 .hiddenInput {
-    -st-compose: hiddenElement;
+    position: absolute;
+    overflow: hidden;
+    height: 1px;
+    width: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    opacity: 0;
 }
 
 .iconContainer {


### PR DESCRIPTION
Changes in theming makes the hiddenElement class that was in `project.st.css` not get to the DOM. I'm reverting back to internal css until I understand how to create general classes