### PR TITLE
Refactoring of component contract

### DIFF
--- a/test/contracts/root-element.spec.tsx
+++ b/test/contracts/root-element.spec.tsx
@@ -3,11 +3,11 @@ import {findDOMNode} from 'react-dom';
 import {ClientRenderer, expect, RenderingContext} from 'test-drive-react';
 import * as WixReactComponents from '../../src';
 import {isReactComponent} from '../utils/is-react-component';
-import {isDecorated, properties, stylable} from "wix-react-tools";
+import {isDecorated, properties} from "wix-react-tools";
 
 const allComponents = Object.keys(WixReactComponents);
 const failingComponents = [
-    'NumberInput', 'Portal', 'Popup', 'TimePicker', 'Modal', 'ContextProvider'
+    'Portal', 'Popup', 'TimePicker', 'Modal', 'ContextProvider'
 ];
 
 describe('Root Element contract', () => {
@@ -44,10 +44,6 @@ export function assertRootElementContract(Component: React.ComponentType<any>): 
 
     it('detects the "properties" feature decorator', () => {
         expect(isDecorated(Component, properties)).to.equal(true);
-    });
-
-    it('detects the "stylable" feature decorator', () => {
-        expect(isDecorated(Component, stylable)).to.equal(true);
     });
 
     it('has display values of \'inline-block\' or \'inline-flex\'', () => {

--- a/test/contracts/root-element.spec.tsx
+++ b/test/contracts/root-element.spec.tsx
@@ -3,6 +3,7 @@ import {findDOMNode} from 'react-dom';
 import {ClientRenderer, expect, RenderingContext} from 'test-drive-react';
 import * as WixReactComponents from '../../src';
 import {isReactComponent} from '../utils/is-react-component';
+import {isDecorated, properties, stylable} from "wix-react-tools";
 
 const allComponents = Object.keys(WixReactComponents);
 const failingComponents = [
@@ -41,28 +42,12 @@ export function assertRootElementContract(Component: React.ComponentType<any>): 
         expect(rootNode).to.be.instanceOf(Element);
     });
 
-    it('performs data-automation-id merge', () => {
-         const {select, rootNode} = render(<Component data-automation-id="CONTRACT_TEST"/>);
-         expect(select('CONTRACT_TEST'), 'data-automation-id not properly merged').to.equal(rootNode);
+    it('detects the "properties" feature decorator', () => {
+        expect(isDecorated(Component, properties)).to.equal(true);
     });
 
-    it('performs data-* attribute merge', () => {
-        const customValue = 'some-custom-value';
-        const {rootNode} = render(<Component data-some-custom-attr={customValue}/>);
-        expect(rootNode).to.have.attribute('data-some-custom-attr');
-        expect(rootNode.getAttribute('data-some-custom-attr')).to.contain(customValue);
-    });
-
-    it('performs inline style merge', () => {
-        const sampleColor = 'rgb(255, 0, 0)';
-        const {rootNode} = render(<Component style={{backgroundColor: sampleColor}}/>);
-        expect(getComputedStyle(rootNode).backgroundColor, 'inline style not properly merged').to.equal(sampleColor);
-    });
-
-    it('performs className merge', () => {
-        const testClassName = 'sample-class-name';
-        const {rootNode} = render(<Component className={testClassName}/>);
-        expect(rootNode.classList.contains(testClassName), 'className not properly merged').to.equal(true);
+    it('detects the "stylable" feature decorator', () => {
+        expect(isDecorated(Component, stylable)).to.equal(true);
     });
 
     it('has display values of \'inline-block\' or \'inline-flex\'', () => {

--- a/test/contracts/root-element.spec.tsx
+++ b/test/contracts/root-element.spec.tsx
@@ -1,9 +1,9 @@
 import React = require('react');
 import {findDOMNode} from 'react-dom';
 import {ClientRenderer, expect, RenderingContext} from 'test-drive-react';
+import {isDecorated, properties} from 'wix-react-tools';
 import * as WixReactComponents from '../../src';
 import {isReactComponent} from '../utils/is-react-component';
-import {isDecorated, properties} from "wix-react-tools";
 
 const allComponents = Object.keys(WixReactComponents);
 const failingComponents = [


### PR DESCRIPTION
The contract now uses wix-react-tools reflection API in order to determine whether all components apply the `properties` decorator. Removed "behavioral" tests.