### PR TITLE
checkbox supports aria-contorls property

### DIFF
--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -11,6 +11,7 @@ export interface CheckBoxProps extends FormInputProps<boolean>, StylableProps {
     children?: React.ReactNode;
     error?: boolean;
     indeterminate?: boolean;
+    ['aria-controls']?: string[];
 }
 
 export interface CheckBoxState {
@@ -72,6 +73,7 @@ export class CheckBox extends React.Component<CheckBoxProps, CheckBoxState> {
                     tabIndex={this.props.tabIndex}
                     autoFocus={this.props.autoFocus}
                     name={this.props.name}
+                    aria-controls={this.props['aria-controls']}
                 />
 
                 <span

--- a/test/components/checkbox.spec.tsx
+++ b/test/components/checkbox.spec.tsx
@@ -289,6 +289,16 @@ describe('<Checkbox/>', () => {
                 expect(checkbox.nativeInput).to.have.attribute('tabIndex', '99998');
             });
         });
+
+        it('takes "aria-controls" property', async () => {
+            const {driver: checkbox, waitForDom} = clientRenderer.render(
+                <CheckBox aria-controls={['123', '345']}/>
+            ).withDriver(CheckBoxTestDriver);
+
+            await waitForDom(() => {
+                expect(checkbox.nativeInput).to.have.attribute('aria-controls', '123,345');
+            });
+        });
     });
 
     describe('When disabled', () => {


### PR DESCRIPTION
An accessibility feature that was left out until now is `aria-controls`. It gets the list of ids of DOM elements that this checkbox value affects.