### PR TITLE
<TreeView /> Initial focus issue fixed

### DIFF
--- a/src/components/tree-view/tree-view.tsx
+++ b/src/components/tree-view/tree-view.tsx
@@ -224,24 +224,24 @@ export class TreeView extends React.Component<TreeViewProps> {
 
     @action
     private onKeyDown = (e: any) => {
-        if (!this.props.focusedItem) { return; }
+        const focusedItem: TreeItemData = this.props.focusedItem || this.props.dataSource[0] as TreeItemData;
 
         switch (e.keyCode) {
             case TreeKeyCodes.RIGHT:
-                e.preventDefault(); this.expandItem(this.props.focusedItem); break;
+                e.preventDefault(); this.expandItem(focusedItem); break;
             case TreeKeyCodes.LEFT:
-                e.preventDefault(); this.collapseItem(this.props.focusedItem); break;
+                e.preventDefault(); this.collapseItem(focusedItem); break;
             case TreeKeyCodes.UP:
-                e.preventDefault(); this.focusPrev(this.props.focusedItem); break;
+                e.preventDefault(); this.focusPrev(focusedItem); break;
             case TreeKeyCodes.DOWN:
-                e.preventDefault(); this.focusNext(this.props.focusedItem); break;
+                e.preventDefault(); this.focusNext(focusedItem); break;
             case TreeKeyCodes.ENTER:
-                e.preventDefault(); this.selectItem(this.props.focusedItem); break;
+                e.preventDefault(); this.selectItem(focusedItem); break;
             case TreeKeyCodes.HOME:
-                this.stateMap.getItemState(this.props.focusedItem).isFocused = false;
+                this.stateMap.getItemState(focusedItem).isFocused = false;
                 e.preventDefault(); this.focusFirst(); break;
             case TreeKeyCodes.END:
-                this.stateMap.getItemState(this.props.focusedItem).isFocused = false;
+                this.stateMap.getItemState(focusedItem).isFocused = false;
                 e.preventDefault(); this.focusLast(); break;
         }
     }

--- a/test/components/tree-view.spec.tsx
+++ b/test/components/tree-view.spec.tsx
@@ -216,11 +216,9 @@ describe('<TreeView />', () => {
 
         describe('Keyboard Navigation', () => {
             it('reacts to keyboard events even when a node is not focused initially', async () => {
-                const {driver: treeViewDemo, waitForDom} = clientRenderer.render(
-                    <TreeViewDemo />
-                ).withDriver(TreeViewDemoDriver);
-
-                const {treeView} = treeViewDemo;
+                const {driver: treeView, waitForDom} = clientRenderer.render(
+                    <TreeView dataSource={treeData} />
+                ).withDriver(TreeViewDriver);
 
                 const nodeChildren = treeData[0].children;
 

--- a/test/components/tree-view.spec.tsx
+++ b/test/components/tree-view.spec.tsx
@@ -215,6 +215,22 @@ describe('<TreeView />', () => {
         });
 
         describe('Keyboard Navigation', () => {
+            it('reacts to keyboard events even when a node is not focused initially', async () => {
+                const {driver: treeViewDemo, waitForDom} = clientRenderer.render(
+                    <TreeViewDemo />
+                ).withDriver(TreeViewDemoDriver);
+
+                const {treeView} = treeViewDemo;
+
+                const nodeChildren = treeData[0].children;
+
+                await waitForDom(() => expect(treeView.getItem(nodeChildren![1].label).root).to.be.absent());
+
+                treeView.pressKey('RIGHT');
+
+                await waitForDom(() => expect(treeView.getItem(nodeChildren![1].label).root).to.be.present());
+            });
+
             it('expands and collapses focused treeItem when right and left arrows are clicked', async () => {
                 const {driver: treeViewDemo, waitForDom} = clientRenderer.render(
                     <TreeViewDemo />


### PR DESCRIPTION
Fixed an issue where without initial interaction with the tree, you could not use keyboard navigation (tab and TV nav keys) to interact with the tree.