### PR TITLE
Fixing <RadioGroup/> tests that require theme

### DIFF
--- a/test/components/radio-group.spec.tsx
+++ b/test/components/radio-group.spec.tsx
@@ -10,6 +10,7 @@ class RadioGroupDemoTestDriver extends DriverBase {
 
     public group: RadioGroupDriver = new RadioGroupDriver(() => this.select('GROUP_1_GROUP'));
 
+    
     public get result(): string | null {
         return this.select('GROUP_1_RESULT').textContent;
     }

--- a/test/components/radio-group.spec.tsx
+++ b/test/components/radio-group.spec.tsx
@@ -3,7 +3,7 @@ import {ClientRenderer, DriverBase, expect, sinon, waitFor} from 'test-drive-rea
 import {RadioGroupDemo} from '../../demo/components/radio-group-demo';
 import {RadioButton, RadioGroup} from '../../src';
 import {RadioButtonDriver, RadioGroupDriver} from '../../test-kit/components/radio-group-driver';
-import {sleep, WithTheme, WithThemeDAID} from '../utils';
+import {sleep} from '../utils';
 
 class RadioGroupDemoTestDriver extends DriverBase {
     public static ComponentClass = RadioGroupDemo;
@@ -17,14 +17,6 @@ class RadioGroupDemoTestDriver extends DriverBase {
 
 describe('<RadioGroup />', () => {
     const clientRenderer = new ClientRenderer();
-    let ThemedContainer;
-    let themedContainer: HTMLDivElement;
-
-    beforeEach(() => {
-        ThemedContainer = WithTheme();
-        const {select} = clientRenderer.render(<ThemedContainer />);
-        themedContainer = select(WithThemeDAID) as HTMLDivElement;
-    });
 
     afterEach(() => {
         clientRenderer.cleanup();
@@ -38,7 +30,7 @@ describe('<RadioGroup />', () => {
 
             const button0 = demo.group.getRadioButton(0);
 
-            await waitForDom(() => { expect(button0.root).to.be.present(); });
+            await waitForDom(() => { expect(button0.root).to.not.be.null});
 
             button0.click();
 
@@ -53,19 +45,18 @@ describe('<RadioGroup />', () => {
             <RadioGroup>
                 <RadioButton value="Ifrit"/>
                 <RadioButton value="Titan"/>
-            </RadioGroup>,
-            themedContainer
+            </RadioGroup>
         ).withDriver(RadioGroupDriver);
 
         const button0 = group.getRadioButton(0);
         const button1 = group.getRadioButton(1);
 
         await waitForDom(() => {
-            expect(button0.root).to.be.present();
+            expect(button0.root).to.not.be.null;
             expect(button0.isChecked(), 'expected radio to be unchecked').to.equal(false);
             expect(button0.value).to.equal('Ifrit');
             expect(button0.nativeElement).to.have.attribute('name', button1.nativeElement.name);
-            expect(button1.root).to.be.present();
+            expect(button1.root).to.not.be.null;
             expect(button1.isChecked(), 'expected radio to be unchecked').to.equal(false);
             expect(button1.value).to.equal('Titan');
 
@@ -108,8 +99,7 @@ describe('<RadioGroup />', () => {
                 <RadioButton value="Fafnir"/>
                 <RadioButton value="Sleipnir"/>
                 <RadioButton value="Snepnir"/>
-            </RadioGroup>,
-            themedContainer
+            </RadioGroup>
         ).withDriver(RadioGroupDriver);
         await waitForDom(() => {
             expect(group.getRadioButton(1).isChecked(), 'expected radio to be checked').to.equal(true);
@@ -137,14 +127,13 @@ describe('<RadioGroup />', () => {
             <RadioGroup onChange={onChange}>
                 <RadioButton value="Leviathan"/>
                 <RadioButton value="Quetzalcoatl"/>
-            </RadioGroup>,
-            themedContainer
+            </RadioGroup>
         ).withDriver(RadioGroupDriver);
 
         const button1 = group.getRadioButton(1);
 
         await waitForDom(() => {
-            expect(button1.root).to.be.present();
+            expect(button1.root).to.not.be.null;
         });
 
         button1.click();
@@ -160,15 +149,14 @@ describe('<RadioGroup />', () => {
             <RadioGroup>
                 <RadioButton value="Garuda"/>
                 <RadioButton value="Ramuh"/>
-            </RadioGroup>,
-            themedContainer
+            </RadioGroup>
         ).withDriver(RadioGroupDriver);
 
         const button0 = group.getRadioButton(0);
         const button1 = group.getRadioButton(1);
 
         await waitForDom(() => {
-            expect(button0.root).to.be.present();
+            expect(button0.root).to.not.be.null;
         });
 
         button0.click();
@@ -184,14 +172,13 @@ describe('<RadioGroup />', () => {
             <RadioGroup>
                 <RadioButton value="Diabolos"/>
                 <RadioButton value="Bahamut"/>
-            </RadioGroup>,
-            themedContainer
+            </RadioGroup>
         ).withDriver(RadioGroupDriver);
 
         const button0 = group.getRadioButton(0);
         const button1 = group.getRadioButton(1);
 
-        await waitForDom(() => { expect(button0.root).to.be.present(); });
+        await waitForDom(() => { expect(button0.root).to.not.be.null; });
 
         button0.click();
 
@@ -216,8 +203,7 @@ describe('<RadioGroup />', () => {
                     <RadioButton value="Alexander"/>
                     <RadioButton value="Odin"/>
                 </RadioGroup>
-            </div>,
-            themedContainer
+            </div>
         );
 
         const group0 = new RadioGroupDriver(() => select('GROUP_0')!);
@@ -227,8 +213,8 @@ describe('<RadioGroup />', () => {
         const button1InGroup1 = group1.getRadioButton(1);
 
         await waitForDom(() => {
-            expect(button0InGroup0.root).to.be.present();
-            expect(button1InGroup1.root).to.be.present();
+            expect(button0InGroup0.root).to.not.be.null;
+            expect(button1InGroup1.root).to.not.be.null;
         });
 
         button0InGroup0.click();
@@ -298,8 +284,7 @@ describe('<RadioGroup />', () => {
             <RadioGroup
                 value="Child1"
                 dataSource={[{value: 'Child0'}, {value: 'Child1'}, {value: 'Child2'}]}
-            />,
-            themedContainer
+            />
         ).withDriver(RadioGroupDriver);
 
         const button0 = group.getRadioButton(0);
@@ -307,13 +292,13 @@ describe('<RadioGroup />', () => {
         const button2 = group.getRadioButton(2);
 
         await waitForDom(() => {
-            expect(button0.root).to.be.present();
+            expect(button0.root).to.not.be.null;
             expect(button0.value).to.equal('Child0');
             expect(button0.isChecked(), 'expected radio to be unchecked').to.equal(false);
-            expect(button1.root).to.be.present();
+            expect(button1.root).to.not.be.null;
             expect(button1.value).to.equal('Child1');
             expect(button1.isChecked(), 'expected radio to be checked').to.equal(true);
-            expect(button2.root).to.be.present();
+            expect(button2.root).to.not.be.null;
             expect(button2.value).to.equal('Child2');
             expect(button2.isChecked(), 'expected radio to be unchecked').to.equal(false);
         });
@@ -482,12 +467,11 @@ describe('<RadioGroup />', () => {
     describe('<RadioButton />', () => {
         it('renders a radio button to the screen', async () => {
             const {driver: radio, waitForDom} = clientRenderer.render(
-                <RadioButton value="Shiva" />,
-                themedContainer
+                <RadioButton value="Shiva" />
             ).withDriver(RadioButtonDriver);
 
             await waitForDom(() => {
-                expect(radio.root).to.be.present();
+                expect(radio.root).to.not.be.null;
                 expect(radio.nativeElement).to.have.attribute('type', 'radio');
                 expect(radio.value).to.equal('Shiva');
                 expect(radio.isChecked(), 'expected radio to be unchecked').to.equal(false);
@@ -497,8 +481,7 @@ describe('<RadioGroup />', () => {
         it('renders the label next to the radio button (right by default)', async () => {
             const distance = 7;
             const {driver: radio, waitForDom} = clientRenderer.render(
-                <RadioButton><span style={{marginLeft: distance + 'px'}}>Omega</span></RadioButton>,
-                themedContainer
+                <RadioButton><span style={{marginLeft: distance + 'px'}}>Omega</span></RadioButton>
             ).withDriver(RadioButtonDriver);
 
             const child = radio.children[0];
@@ -538,12 +521,11 @@ describe('<RadioGroup />', () => {
         it('calls the onClick function when clicked', async () => {
             const onChange = sinon.spy();
             const {driver: radio, waitForDom} = clientRenderer.render(
-                <RadioButton value="Tonberry" onChange={onChange}/>,
-                themedContainer
+                <RadioButton value="Tonberry" onChange={onChange}/>
             ).withDriver(RadioButtonDriver);
 
             await waitForDom(() => {
-                expect(radio.root).to.be.present();
+                expect(radio.root).to.not.be.null;
             });
 
             radio.click();

--- a/test/components/radio-group.spec.tsx
+++ b/test/components/radio-group.spec.tsx
@@ -10,7 +10,6 @@ class RadioGroupDemoTestDriver extends DriverBase {
 
     public group: RadioGroupDriver = new RadioGroupDriver(() => this.select('GROUP_1_GROUP'));
 
-    
     public get result(): string | null {
         return this.select('GROUP_1_RESULT').textContent;
     }

--- a/test/components/radio-group.spec.tsx
+++ b/test/components/radio-group.spec.tsx
@@ -30,7 +30,7 @@ describe('<RadioGroup />', () => {
 
             const button0 = demo.group.getRadioButton(0);
 
-            await waitForDom(() => { expect(button0.root).to.not.be.null});
+            await waitForDom(() => { expect(button0.root).to.not.be.null; });
 
             button0.click();
 


### PR DESCRIPTION
Themes exported control over `height` and `width` to the theme. Since tests do not use themed components the `.present()` matcher fails on component having no width or height. To mitigate I replaced `.present()` with `not.be.null` until a better solution exists