### PR TITLE
Update documentation with things related to Theme

### DIFF
--- a/docs/button/README.md
+++ b/docs/button/README.md
@@ -1,0 +1,12 @@
+# Button
+
+The Button component simply wraps a native `<button/>` tag.
+
+Use it as you would a native Button.
+
+The component is used to provide default styling for the buttons.
+
+Guideline:
+
+* If you need your button styled with your theme for buttons, use this component
+* If you only need native button functionality, but not the style, use a native button

--- a/docs/checkbox/readme.md
+++ b/docs/checkbox/readme.md
@@ -6,21 +6,21 @@ The **Checkbox** component provides the same functionality as the native Checkbo
 
 ### Properties
 
-| name        | type       | default | required | description       |
-| ----------- | ---------- | ------- | -------- | ----------------- |
-| value | boolean | false | no | The value chosen in the checkbox. |
-| onChange | function | NOOP | no | Event triggered by changing the value.<br>`(event : ChangeEvent) => void` |
-| disabled | boolean | false | no | Whether the checkbox responds to events. |
-| readOnly | boolean | false | no | Gains tab focus but user cannot change value. |
-| tabIndex | number | 0 | no | Determines the order by which the component gains tab focus. |
-| id | string |  | no | Puts an ID property to be used for HTML labels. |
-| children | React.ReactNode | null | no | children | Any further nodes will be rendered after the checkbox element |
-| boxIcon | React component |  | no | Component representing an empty state. |
-| indeterminateIcon | React component |  | no | Component representing an indeterminate state. |
-| tickIcon | React component |  | no | Component representing a checked state. This will be overlayed on top of the boxIcon. |
-| indeterminate | boolean | false | no | Indicates that the checkbox is neither on nor off. Changes the appearance to resemble a third state. Does not affect the value of the checked attribute, and clicking the checkbox will set the value to false. |
-| autoFocus | boolean | false | no | Whether the checkbox receives focus automatically when page loads |
-| name | string |  | no | Name is used for form data reference |
+| name              | type            | default | required | description                              |
+| ----------------- | --------------- | ------- | -------- | ---------------------------------------- |
+| value             | boolean         | false   | no       | The value chosen in the checkbox.        |
+| onChange          | function        | NOOP    | no       | Event triggered by changing the value.<br>`(event : ChangeEvent) => void` |
+| disabled          | boolean         | false   | no       | Whether the checkbox responds to events. |
+| readOnly          | boolean         | false   | no       | Gains tab focus but user cannot change value. |
+| tabIndex          | number          | 0       | no       | Determines the order by which the component gains tab focus. |
+| id                | string          |         | no       | Puts an ID property to be used for HTML labels. |
+| children          | React.ReactNode | null    | no       | children                                 |
+| boxIcon           | React component |         | no       | Component representing an empty state.   |
+| indeterminateIcon | React component |         | no       | Component representing an indeterminate state. |
+| tickIcon          | React component |         | no       | Component representing a checked state. This will be overlayed on top of the boxIcon. |
+| indeterminate     | boolean         | false   | no       | Indicates that the checkbox is neither on nor off. Changes the appearance to resemble a third state. Does not affect the value of the checked attribute, and clicking the checkbox will set the value to false. |
+| autoFocus         | boolean         | false   | no       | Whether the checkbox receives focus automatically when page loads |
+| name              | string          |         | no       | Name is used for form data reference     |
 
 
 ### React Code Example
@@ -58,15 +58,26 @@ export class BasicDemo extends React.Component<{}, {value: boolean}> {
 
 ## Style API
 
+### Subcomponents (pseudo-elements)
+
+| selector            | description                              |
+| ------------------- | ---------------------------------------- |
+| ::box               | Frame of the checkbox                    |
+| ::icon              | Positioning and size for both icons      |
+| ::tickIcon          | Graphic of the Checkmark icon. Use `background-image` to change |
+| ::indeterminateIcon | Graphic of the Indeterminate icon. Use `background-image` to change |
+
+
+
 ### Custom CSS States (pseudo-classes)
 
-| state | description |
-|-------|--------------|
-| :checked | Used to style component when checked. |
-| :disabled | Used to style component when disabled. |
+| state          | description                              |
+| -------------- | ---------------------------------------- |
+| :checked       | Used to style component when checked.    |
+| :disabled      | Used to style component when disabled.   |
 | :indeterminate | Used to style component when value indeterminate. |
-| :readonly | Used to style component when in readonly mode. |
-| :focused | Used to style component when gains focus. |
+| :readonly      | Used to style component when in readonly mode. |
+| :focused       | Used to style component when gains focus. |
 
 ### Style Code Example
 

--- a/docs/input/README.md
+++ b/docs/input/README.md
@@ -1,0 +1,12 @@
+# Input
+
+The Input component simply wraps a native React Input.
+
+Use it as you would a native Input.
+
+The component is used to provide default styling for a native input component.
+
+Guideline:
+
+* If you need your input styled, use this component
+* If you only need native input functionality, but not the style, use a native input

--- a/docs/number-input/README.md
+++ b/docs/number-input/README.md
@@ -10,23 +10,23 @@ The **NumberInput** component improves upon the native `<input type="number">` b
 
 ### Props
 
-| name         | type                             | defaultValue | isRequired | description                              |
-| ------------ | -------------------------------- | ------------ | ---------- | ---------------------------------------- |
-| value        | number                           |              |            | Used to set and change the value of the input. If you bind this to a state in your parent component, you should also set the `onChange` handler in order for the component to work.<br>If value is empty, the component instance behaves as uncontrolled. |
-| defaultValue | number                           |              |            | Sets the default value if the input is uncontrolled. |
-| placeholder  | string                           |              |            | Text to display if the value is null.    |
-| min          | number                           | 1            |            |                                          |
-| max          | number                           | 100          |            |                                          |
-| step         | number                           | 1            |            |                                          |
-| required     | boolean                             | false        |            | Whether or not filling the value is required in a form. |
-| disabled     | boolean                             | false        |            | If true, the component will not be interactable. |
-| label        | string                           |              |            | Text to display in accessibility mode.   |
-| name         | string                           |              |            | The name of the component. Behaves like the name attribute of an input element. |
-| prefix       | node                             |              |            | Inserts a component at the start of the input. |
-| suffix       | node                             |              |            | Inserts a component at the end of the input. |
-| onChange     | function |   |   | Callback function that is fired on component blur.<br>`(event: {value: number}): void`<br>`event` KeyDown event for current component instance.<br>`newValue` The new value of the component instance. |
-| onInput      |function |   |  | Callback function that is fired on every keydown event.<br> `(event: {value: number}): void`<br>`event` KeyDown event targeting component instance.<br>`newValue` The new value of the component instance. |
-| error        | boolean                        | false        |            | Sets the `:error` CSS state on the current component instance. |
+| name         | type     | defaultValue | isRequired | description                              |
+| ------------ | -------- | ------------ | ---------- | ---------------------------------------- |
+| value        | number   |              |            | Used to set and change the value of the input. If you bind this to a state in your parent component, you should also set the `onChange` handler in order for the component to work.<br>If value is empty, the component instance behaves as uncontrolled. |
+| defaultValue | number   |              |            | Sets the default value if the input is uncontrolled. |
+| placeholder  | string   |              |            | Text to display if the value is null.    |
+| min          | number   | 1            |            |                                          |
+| max          | number   | 100          |            |                                          |
+| step         | number   | 1            |            |                                          |
+| required     | boolean  | false        |            | Whether or not filling the value is required in a form. |
+| disabled     | boolean  | false        |            | If true, the component will not be interactable. |
+| label        | string   |              |            | Text to display in accessibility mode.   |
+| name         | string   |              |            | The name of the component. Behaves like the name attribute of an input element. |
+| prefix       | node     |              |            | Inserts a component at the start of the input. |
+| suffix       | node     |              |            | Inserts a component at the end of the input. |
+| onChange     | function |              |            | Callback function that is fired on component blur.<br>`(event: {value: number}): void`<br>`event` KeyDown event for current component instance.<br>`newValue` The new value of the component instance. |
+| onInput      | function |              |            | Callback function that is fired on every keydown event.<br> `(event: {value: number}): void`<br>`event` KeyDown event targeting component instance.<br>`newValue` The new value of the component instance. |
+| error        | boolean  | false        |            | Sets the `:error` CSS state on the current component instance. |
 
 ### Code Examples
 
@@ -88,18 +88,19 @@ export class ComponentsDemo extends React.Component<{}, {}>{
 
 ### Subcomponents (pseudo elements)
 
-| selector  | description                            | type                                     |
-| --------- | -------------------------------------- | ---------------------------------------- |
-| ::stepper | Style the stepper arrows. | Style the internal `<stepper/>` component. This component exposes some internal styles. |
-| ::stepper::up   | Style the stepper UP arrow.   | Style the internal `<up/>` arrow component.|
-| ::stepper::down | Style the stepper DOWN arrow. | Style the internal `<down/>` arrow component. |
+| selector        | description                              |
+| --------------- | ---------------------------------------- |
+| ::stepper       | Style the stepper arrows (this is an internal `Stepper` component) |
+| ::stepper::up   | Style the stepper UP arrow.              |
+| ::stepper::down | Style the stepper DOWN arrow.            |
+| ::nativeInput   | Override native input styles             |
 
 ### Custom CSS States (pseudo classes)
 
 | selector                       | description                              |
 | ------------------------------ | ---------------------------------------- |
 | :error                         | Style the component on error, i.e. when the `error` prop is true. |
-| :hover, :focus, :disabled, etc | Standard CSS pseudo classes.              |
+| :hover, :focus, :disabled, etc | Standard CSS pseudo classes.             |
 
 ### Style Code Examples
 
@@ -124,3 +125,4 @@ NumberInput::stepper::down:hover, NumberInput::stepper::up:hover {
   background-color:lightblue;
 }
 ```
+

--- a/docs/radiogroup/README.md
+++ b/docs/radiogroup/README.md
@@ -11,16 +11,16 @@ The **RadioGroup** component is used to group together children and provide them
 
 **RadioGroup**:
 
-| Name | Type | Default | Required | Description |
-| -- | -- | -- | -- | -- |
-| name | string | null | no | The name of the group. sets the _name_ property on each child |
-| id | string | null | no | Unique identifier |
-| tabIndex | number | 0 | no | Tab order of the element, copied to the element in focus (not on the root) |
-| disabled | boolean | false | no | Whether all the radio buttons are disabled |
-| readonly | boolean | false | no | Whether the group value cannot be changed |
-| value | string | null | no | The value of the selected element |
-| onChange | (event: ChangeEvent) => void | NOOP | no | Triggered by changing a radio button state to selected |
-| children | React.ReactNode | null | no | children |
+| Name     | Type                         | Default | Required | Description                              |
+| -------- | ---------------------------- | ------- | -------- | ---------------------------------------- |
+| name     | string                       | null    | no       | The name of the group. sets the _name_ property on each child |
+| id       | string                       | null    | no       | Unique identifier                        |
+| tabIndex | number                       | 0       | no       | Tab order of the element, copied to the element in focus (not on the root) |
+| disabled | boolean                      | false   | no       | Whether all the radio buttons are disabled |
+| readonly | boolean                      | false   | no       | Whether the group value cannot be changed |
+| value    | string                       | null    | no       | The value of the selected element        |
+| onChange | (event: ChangeEvent) => void | NOOP    | no       | Triggered by changing a radio button state to selected |
+| children | React.ReactNode              | null    | no       | children                                 |
 
 The following props are part of the DataInterface (name to be decided):
 
@@ -32,17 +32,17 @@ The following props are part of the DataInterface (name to be decided):
 
 **RadioButton**:
 
-| Name | Type | Default | Required | Description |
-| -- | -- | -- | -- | -- |
-| checked | boolean | false | no | Whether the button appears checked |
-| id | string | null | no | Unique identifier |
-| tabIndex | number | -1 \| tabIndex set by RadioGroup | Tab of order of the element |
-| name | string | null | no | The name of the group that this button is part of |
-| disabled | boolean | false | no | Whether this button appears as disabled |
-| readonly | boolean | false | no | Whether this button's value can be changed |
-| value | string | no | Yes | The value of the radio button |
-| onChange | (event: ChangeEvent) => void | NOOP | no | Triggered by changing the button's state |
-| children | React.ReactNode | null | no | children | Any further nodes will be rendered. |
+| Name     | Type                         | Default                          | Required                    | Description                              |
+| -------- | ---------------------------- | -------------------------------- | --------------------------- | ---------------------------------------- |
+| checked  | boolean                      | false                            | no                          | Whether the button appears checked       |
+| id       | string                       | null                             | no                          | Unique identifier                        |
+| tabIndex | number                       | -1 \| tabIndex set by RadioGroup | Tab of order of the element |                                          |
+| name     | string                       | null                             | no                          | The name of the group that this button is part of |
+| disabled | boolean                      | false                            | no                          | Whether this button appears as disabled  |
+| readonly | boolean                      | false                            | no                          | Whether this button's value can be changed |
+| value    | string                       | no                               | Yes                         | The value of the radio button            |
+| onChange | (event: ChangeEvent) => void | NOOP                             | no                          | Triggered by changing the button's state |
+| children | React.ReactNode              | null                             | no                          | children                                 |
 
 ### React Code Examples
 
@@ -112,17 +112,28 @@ export class Example2 extends React.Component<{}, {}>{
 
 #### **RadioGroup** Subcomponents (pseudo-elements)
 
-| selector | description  |
-|----------|--------------|
-| ::option | Allows styling the children under the *RadioGroup* |
+| selector | description                              |
+| -------- | ---------------------------------------- |
+| ::option | Allows styling the children under the *RadioGroup*. This subcomponent is a RadioButton. See its style API below |
+
+
+
+#### **RadioButton** Subcomponents (pseudo-elements)
+
+| selector           | description                              |
+| ------------------ | ---------------------------------------- |
+| ::contentContainer | Style the div containing the button and the children passed to the component |
+| ::button           | Style the actual button graphics for the RadioButton (use the `:checked` state to style the icon) |
+
+#### 
 
 #### **RadioButton** Custom CSS States (pseudo-classes)
 
-| state | description |
-| ----- | ----------- |
-| :disabled | Style the button when it is disabled |
-| :focused | Style the component when it gets document focus |
-| :checked |  Style the button when it is checked |
+| state     | description                              |
+| --------- | ---------------------------------------- |
+| :disabled | Style the button when it is disabled     |
+| :focused  | Style the component when it gets document focus |
+| :checked  | Style the button when it is checked      |
 
 ### Style Code Example
 

--- a/docs/stepper/README.md
+++ b/docs/stepper/README.md
@@ -12,13 +12,13 @@
 
 ##### Component Props
 
-| name        | type      | defaultValue | isRequired | description  |
-| ----------- | --------- | ------------ | ---------- | ------------ |
-| disableUp   | boolean   | false        | no         | Disables **up** arrow.    |
-| disableDown | boolean   | false        | no         | Disables **down** arrow.  |
-| dragStep    | number    | 10           | no         | Defines how many pixels the user drags the cursor on mousedown to fire the `onUp` and `onDown` functions. |
-| onUp        | function |  | no  | Callback function that is fired on **step up** events: mouse click, Up Arrow Key, drag step. <br> `(modifiers: Modifiers): void;` <br> `Modifiers` altKey, ctrlKey, shiftKey |
-| onDown      | function |  | no | Callback function that is fired on **step down** events: mouse click, Down Arrow Key, drag step. <br> `(modifiers: Modifiers): void;` <br> `Modifiers` altKey, ctrlKey, shiftKey |
+| name        | type     | defaultValue | isRequired | description                              |
+| ----------- | -------- | ------------ | ---------- | ---------------------------------------- |
+| disableUp   | boolean  | false        | no         | Disables **up** arrow.                   |
+| disableDown | boolean  | false        | no         | Disables **down** arrow.                 |
+| dragStep    | number   | 10           | no         | Defines how many pixels the user drags the cursor on mousedown to fire the `onUp` and `onDown` functions. |
+| onUp        | function |              | no         | Callback function that is fired on **step up** events: mouse click, Up Arrow Key, drag step. <br> `(modifiers: Modifiers): void;` <br> `Modifiers` altKey, ctrlKey, shiftKey |
+| onDown      | function |              | no         | Callback function that is fired on **step down** events: mouse click, Down Arrow Key, drag step. <br> `(modifiers: Modifiers): void;` <br> `Modifiers` altKey, ctrlKey, shiftKey |
 
 ### Code Examples
 
@@ -46,15 +46,17 @@ return (
 
 ### Subcomponents (pseudo-elements)
 
-| selector | description          |
-| -------- | -------------------- |
+| selector | description               |
+| -------- | ------------------------- |
 | ::up     | Style the **up** arrow.   |
 | ::down   | Style the **down** arrow. |
 
+Note: change the arrow icons by overriding `background-image` in the `::up` and `::down` elements
+
 ### Custom CSS States (pseudo-classes)
 
-| selector                       | description                 |
-| ------------------------------ | --------------------------- |
+| selector                       | description                  |
+| ------------------------------ | ---------------------------- |
 | :hover, :focus, :disabled, etc | Standard CSS pseudo classes. |
 
 ### Style Code Examples

--- a/docs/time-picker/README.md
+++ b/docs/time-picker/README.md
@@ -14,20 +14,20 @@ The **TimePicker** component allows users to select the time and switch between 
 
 ### Component Props
 
-| name        | type                            | defaultValue   | isRequired | description                              |
-| ----------- | ------------------------------- | -------------- | ---------- | ---------------------------------------- |
-| value       | string                          |                | yes        | Sets and represents the time shown in the component instance.<br>Accepts strings in 24h format (12:54). |
-| placeholder | string                          |                |            | Text to display if the value is null.    |
+| name        | type                       | defaultValue   | isRequired | description                              |
+| ----------- | -------------------------- | -------------- | ---------- | ---------------------------------------- |
+| value       | string                     |                | yes        | Sets and represents the time shown in the component instance.<br>Accepts strings in 24h format (12:54). |
+| placeholder | string                     |                |            | Text to display if the value is null.    |
 | format      | enum:<br>"ampm",<br>"24hr" | system default |            | Tells the component instance to present the time in ampm (12hr) format or 24hr format. |
-| required    | boolean                            | false          |            | Whether or not filling the value is required in a form. |
-| disabled    | boolean                            | false          |            | If `true`, the  component instance will not be interactive. |
-| label       | string                          |                |            | Text to display in accessibility mode.   |
-| name        | string                          |                |            | The name of the component instance. Behaves like the name attribute of an input element. |
-| prefix      | node                            |                |            | Inserts a component at the start of the input. |
-| suffix      | node                            |                |            | Inserts a component at the end of the input. |
-| onChange     | function |   |   | Callback function that is fired on component blur.<br>`(event: {value: number}): void`<br>`event` KeyDown event targeting the component instance.<br>`newValue` The new value of the component instance. |
-| onInput      |function |   |  | Callback function that is fired on every keydown event.<br> `(event: {value: number}): void`<br>`event` KeyDown event targeting the component instance.<br>`newValue` The new value of the component instance. |
-| error       | boolean                            | false          |            | Sets the `:error` CSS state of the component instance. |
+| required    | boolean                    | false          |            | Whether or not filling the value is required in a form. |
+| disabled    | boolean                    | false          |            | If `true`, the  component instance will not be interactive. |
+| label       | string                     |                |            | Text to display in accessibility mode.   |
+| name        | string                     |                |            | The name of the component instance. Behaves like the name attribute of an input element. |
+| prefix      | node                       |                |            | Inserts a component at the start of the input. |
+| suffix      | node                       |                |            | Inserts a component at the end of the input. |
+| onChange    | function                   |                |            | Callback function that is fired on component blur.<br>`(event: {value: number}): void`<br>`event` KeyDown event targeting the component instance.<br>`newValue` The new value of the component instance. |
+| onInput     | function                   |                |            | Callback function that is fired on every keydown event.<br> `(event: {value: number}): void`<br>`event` KeyDown event targeting the component instance.<br>`newValue` The new value of the component instance. |
+| error       | boolean                    | false          |            | Sets the `:error` CSS state of the component instance. |
 
 ### Code Example
 
@@ -82,12 +82,17 @@ export class ComponentsDemo extends React.Component<{}, {}>{
 
 ### Subcomponents (pseudo-elements)
 
-| selector      | description                            | type                                     |
-| :------------ | -------------------------------------- | ---------------------------------------- |
-| ::stepper     | Allows you to style the stepper arrows. | Style the internal `<Stepper/>` component. This component exposes some internal styles. |
-| ::stepper::up   | Style the stepper UP arrow.   | Style the internal `<up/>` arrow component.|
-| ::stepper::down | Style the stepper DOWN arrow. | Style the internal `<down/>` arrow component. |
-| ::placeholder | Allows you to style the placeholder. | This subcomponent is an HTML Element and has no subcomponents of its own. |
+| selector        | description                              | notes                                    |
+| :-------------- | ---------------------------------------- | ---------------------------------------- |
+| ::time          | Wrapper for both of the time inputs (hours and minutes) | Use it to style and align both inputs together |
+| ::input         | This selector styles the time inputs (hours and minutes) themselves |                                          |
+| ::colon         | The colon symbol between the time inputs |                                          |
+| ::nativeInput   | TStyles the native time input which only appears on Touch devices (where a nice native input is implemented) |                                          |
+| ::ampm          | The AM/PM switch                         |                                          |
+| ::stepper       | Allows you to style the stepper arrows.  | Style the internal `<Stepper/>` component. This component exposes some internal styles. |
+| ::stepper::up   | Style the stepper UP arrow.              |                                          |
+| ::stepper::down | Style the stepper DOWN arrow.            |                                          |
+| ::placeholder   | Allows you to style the placeholder.     | This subcomponent is an HTML Element and has no subcomponents of its own. |
 
 You can change color of the `::placeholder` subcomponent by setting the `color` property.
 
@@ -100,9 +105,11 @@ TimePicker::placeholder {
 
 ### Custom CSS States (pseudo-classes)
 
-| state                   | description                              |
-| ----------------------- | ---------------------------------------- |
-| :error                  | Style the component instance on error, i.e. when the `error` prop is true. |
+| state                          | description                              |
+| ------------------------------ | ---------------------------------------- |
+| :error                         | Style the component instance on error, i.e. when the `error` prop is true. |
+| :empty                         | Style the empty state                    |
+| :rtl                           | Adjust the look of the component in RTL mode |
 | :hover, :focus, :disabled, etc | Standard CSS states                      |
 
 

--- a/docs/toggle/README.md
+++ b/docs/toggle/README.md
@@ -8,15 +8,15 @@ A toggle switch is used as an on/off control
 
 #### Props
 
-| name     | type   | defaultValue | isRequired | description                              |
-| -------- | ------ | ------------ | :--------- | ---------------------------------------- |
-| value    | bool   | false        |            |                                          |
-| onChange | `(event: {value: boolean}): void`	   |              |            | Callback function when user changes the value of the component |
-| required | bool   | false        |            | Whether or not filling the value is required in a form. |
-| name     | string |              |            | The name of the toggle. Behaves like the name attribute of an input element. |
-| disabled | bool   | false        |            | If `true`, the toggle will not be interactive |
-| label    | string |              |            | Text to display in accessibility mode    |
-| error    | bool   | false        |            | Sets the `:error` CSS state on the `<toggle/>` |
+| name     | type                              | defaultValue | isRequired | description                              |
+| -------- | --------------------------------- | ------------ | :--------- | ---------------------------------------- |
+| value    | bool                              | false        |            |                                          |
+| onChange | `(event: {value: boolean}): void` |              |            | Callback function when user changes the value of the component |
+| required | bool                              | false        |            | Whether or not filling the value is required in a form. |
+| name     | string                            |              |            | The name of the toggle. Behaves like the name attribute of an input element. |
+| disabled | bool                              | false        |            | If `true`, the toggle will not be interactive |
+| label    | string                            |              |            | Text to display in accessibility mode    |
+| error    | bool                              | false        |            | Sets the `:error` CSS state on the `<toggle/>` |
 
 #### Accepted Children
 
@@ -87,6 +87,7 @@ Toggle:checked::switch {
 | ------------------------------ | ---------------------------------------- |
 | :error                         | Style the component on error, i.e. when the `error` prop is true |
 | :checked                       | Style the toggle element in checked state |
+| :rtl                           | Style the component in RTL mode          |
 | :hover, :focus, :disabled, etc | Standard CSS state                       |
 
 

--- a/src/themes/wix/components/time-picker.st.css
+++ b/src/themes/wix/components/time-picker.st.css
@@ -55,7 +55,7 @@ TimePicker::input {
 }
 
 
-TimePicker::input::placeholder {
+TimePicker::placeholder {
   font: value(fontStyle);
   color: value(placeholderColor);
 }


### PR DESCRIPTION
You can see the current status of the documentation here:
https://docs.google.com/spreadsheets/d/1y5h43xNKcMnNbn_GTV-4XSBRDbNmHj8YRYjel26uGto/edit#gid=2047332282

Docs for some components weren't updated because the components are unfinished, in the process of changing, have open pull requests, or their final implementation is blocked by something.

(Notably Portal incompatibility with Theming, and the bug with not being able to expose elements stored in variables or functions as subselectors)