### PR TITLE
augmenting the autofocus test to not warn on IE

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -35,7 +35,7 @@ const sauceLabsLaunchers = { // Check out https://saucelabs.com/platforms for al
         base: 'SauceLabs',
         platform: 'macOS 10.12',
         browserName: 'safari',
-        version: '11.0'
+        version: '10.0'
     },
     slSafari9: {
         base: 'SauceLabs',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -35,7 +35,7 @@ const sauceLabsLaunchers = { // Check out https://saucelabs.com/platforms for al
         base: 'SauceLabs',
         platform: 'macOS 10.12',
         browserName: 'safari',
-        version: '10.0'
+        version: '11.0'
     },
     slSafari9: {
         base: 'SauceLabs',

--- a/test/components/checkbox.spec.tsx
+++ b/test/components/checkbox.spec.tsx
@@ -214,21 +214,20 @@ describe('<Checkbox/>', () => {
     });
 
     it('Accepts "autofocus" prop', async () => {
-        const {driver: checkbox, waitForDom} = clientRenderer.render(
-            <CheckBox  autoFocus/>
-        ).withDriver(CheckBoxTestDriver);
+        if (document.visibilityState === 'visible' && document.hasFocus()) {
+            const {driver: checkbox, waitForDom} = clientRenderer.render(
+                <CheckBox  autoFocus/>
+            ).withDriver(CheckBoxTestDriver);
 
-        await waitForDom(() => {
-            if (document.hasFocus()) {
-                    expect(document.activeElement).to.equal(checkbox.nativeInput);
-                    expect(checkbox.elementHasStylableState('focus')).to.equal(true);
-
-            } else {
-                console.warn(// tslint:disable-line no-console
-                    'Checkbox autofocus test wasn\'t run since document doesn\'t have focus'
-                );
-            }
-        });
+            await waitForDom(() => {
+                expect(document.activeElement).to.equal(checkbox.nativeInput);
+                expect(checkbox.elementHasStylableState('focus')).to.equal(true);
+            });
+        } else {
+            console.warn(// tslint:disable-line no-console
+                'Checkbox autofocus test wasn\'t run since document doesn\'t have focus'
+            );
+        }
     });
 
     describe('Accessibility features', () => {

--- a/test/components/checkbox.spec.tsx
+++ b/test/components/checkbox.spec.tsx
@@ -214,12 +214,10 @@ describe('<Checkbox/>', () => {
     });
 
     it('Accepts "autofocus" prop', async () => {
+        const {driver: checkbox, waitForDom} = clientRenderer.render(
+            <CheckBox  autoFocus/>
+        ).withDriver(CheckBoxTestDriver);
         if (document.hasFocus()) {
-
-            const {driver: checkbox, waitForDom} = clientRenderer.render(
-                <CheckBox  autoFocus/>
-            ).withDriver(CheckBoxTestDriver);
-
             await waitForDom(() => {
                 expect(document.activeElement).to.equal(checkbox.nativeInput);
                 expect(checkbox.elementHasStylableState('focus')).to.equal(true);

--- a/test/components/checkbox.spec.tsx
+++ b/test/components/checkbox.spec.tsx
@@ -217,17 +217,18 @@ describe('<Checkbox/>', () => {
         const {driver: checkbox, waitForDom} = clientRenderer.render(
             <CheckBox  autoFocus/>
         ).withDriver(CheckBoxTestDriver);
-        if (document.hasFocus()) {
-            await waitForDom(() => {
-                expect(document.activeElement).to.equal(checkbox.nativeInput);
-                expect(checkbox.elementHasStylableState('focus')).to.equal(true);
-            });
 
-        } else {
-            console.warn(// tslint:disable-line no-console
-                'Checkbox autofocus test wasn\'t run since document doesn\'t have focus'
-            );
-        }
+        await waitForDom(() => {
+            if (document.hasFocus()) {
+                    expect(document.activeElement).to.equal(checkbox.nativeInput);
+                    expect(checkbox.elementHasStylableState('focus')).to.equal(true);
+
+            } else {
+                console.warn(// tslint:disable-line no-console
+                    'Checkbox autofocus test wasn\'t run since document doesn\'t have focus'
+                );
+            }
+        });
     });
 
     describe('Accessibility features', () => {


### PR DESCRIPTION
Currently the checkbox component has a test for autoFocus prop. Strait-forwardly this test would fail on a browser window that isn't focused, so the test has a condition that runs the test if it has focus and doesn't if not. This PR aims to fix a problem with the test not running on IE & Safari.