### PR TITLE
<ContextProvider /> improvements

### DIFF
--- a/src/components/context-provider/context-provider.tsx
+++ b/src/components/context-provider/context-provider.tsx
@@ -6,28 +6,27 @@ export interface ContextProviderProps {
     dir?: 'ltr' | 'rtl' | 'auto';
     tagName?: string;
     className?: string;
-    style?: object;
+    style?: React.CSSProperties;
     children?: React.ReactNode;
     [key: string]: any;
 }
 
 export class ContextProvider extends React.PureComponent<ContextProviderProps> {
-    public static childContextTypes = {
-        contextProvider: PropTypes.object
-    };
-
-    public static defaultProps = {
-        tagName: 'div'
-    };
+    public static childContextTypes = {contextProvider: PropTypes.object};
+    public static contextTypes = {contextProvider: PropTypes.object};
+    public static defaultProps = {tagName: 'div'};
 
     public getChildContext() {
         return {
-            contextProvider: omit(this.props, 'tagName', 'style', 'children', 'className')
+            contextProvider: {
+                ...this.context.contextProvider,
+                ...omit(this.props, 'tagName', 'style', 'children', 'className', 'data-automation-id')
+            }
         };
     }
 
     public render() {
-        const {tagName, className, style, dir, children} = this.props;
-        return  React.createElement(tagName!, {className, style, dir, children});
+        const {tagName, className, style, dir, children, 'data-automation-id': automationId} = this.props;
+        return React.createElement(tagName!, {className, style, dir, children, 'data-automation-id': automationId});
     }
 }

--- a/src/utils/omit.ts
+++ b/src/utils/omit.ts
@@ -1,4 +1,4 @@
-export function omit<T extends {[key: string]: any}>(obj: T, ...skip: string[]): Partial<T> {
+export function omit<T extends {[key: string]: any}>(obj: T, ...skip: Array<keyof T>): Partial<T> {
     return Object.keys(obj).reduce<Partial<T>>((acc, key) => {
         if (skip.indexOf(key) === -1) {
             acc[key] = obj[key];


### PR DESCRIPTION
- Now forwards upper level context values as well (overwriting with its own).
- Refactored tests for readability. no more `any`. no more `let`.
- Simplified test components.
- Rephrased test descriptions to describe the actual *behavior* being tested.
- Tests no longer use `ReactDOM.findDOMNode()`. We use test-drive's `select()`.
- Assertions are now full sentences, in the spirit of chai.
- Removed test of Symbol prop, as React doesn't support it yet.