### PR TITLE
Disable TimePicker/DatePicker tests (see desc)

### DIFF
--- a/test/components/date-picker.spec.tsx
+++ b/test/components/date-picker.spec.tsx
@@ -25,7 +25,7 @@ class DatePickerDemoDriver extends DriverBase {
     }
 }
 
-describe('The DatePicker Component', () => {
+describe.skip('The DatePicker Component', () => {
     const clientRenderer = new ClientRenderer();
     afterEach(() => clientRenderer.cleanup());
 

--- a/test/components/time-picker.spec.tsx
+++ b/test/components/time-picker.spec.tsx
@@ -36,7 +36,7 @@ interface Suit {
     ]];
 }
 
-describe('<TimePicker/>', () => {
+describe.skip('<TimePicker/>', () => {
     const clientRenderer = new ClientRenderer();
     afterEach(() => clientRenderer.cleanup());
 


### PR DESCRIPTION
these tests causes browser failures in IE11. It happens in our CI and **also locally**. Might have to do with the locale settings of the environment being tested on

Committed this to a PR to check if this is indeed the root cause of the issue.